### PR TITLE
Apply Liquid editorial theme across the site

### DIFF
--- a/liquid-design-system.md
+++ b/liquid-design-system.md
@@ -1,0 +1,572 @@
+# Liquid AI — Look & Feel Specification
+
+A portable design-system spec reverse-engineered from the live tokens and computed styles on
+[liquid.ai](https://www.liquid.ai/) (captured 2026-08-08). Every value below was read off the running
+page — CSS custom properties, `getComputedStyle()` on real elements, and stylesheet rule extraction —
+at **six viewport widths: 375, 640, 768, 1024, 1280, 1440**.
+
+Fonts have been re-specified as **100% open / free** (see §7). The one proprietary face in the original
+(Iowan Old Style, an Apple system font) has an empirically-chosen OFL replacement.
+
+Pair this with [`liquid-theme.css`](liquid-theme.css) — a drop-in stylesheet implementing everything here,
+mobile behaviour included.
+
+---
+
+## 1. The idea in one paragraph
+
+A near-black editorial canvas. Structure comes from **hairline rules**, not from cards, shadows, or
+rounded boxes — content sits inside a ruled grid like a broadsheet newspaper. Type carries the
+personality: a **high-contrast old-style serif** for every headline (italic for emphasis), a neutral
+grotesque for body copy, and a **technical uppercase face at 11px** for labels, metadata, and tickers.
+Colour is almost entirely absent — a single **soft periwinkle-violet** does all the accent work, and it
+glows rather than fills. The result reads as *research lab*, not *SaaS landing page*.
+
+Four rules to keep the feel intact:
+
+1. **Rules over boxes.** Separate things with 1px `rgba(255,255,255,0.13)` lines. No shadows, no card radii.
+2. **Serif headlines, always,** at weight 400 with hard negative tracking. Italic is the emphasis mechanism.
+3. **One accent, used sparingly.** `#ac8dff` on maybe two elements per viewport, plus a soft glow.
+4. **The layout changes character at 1024px,** not gradually. See §5.
+
+---
+
+## 2. Colour
+
+### Core palette
+
+| Token | Value | Use |
+|---|---|---|
+| `--background` | `#0a0a0a` | Page canvas (neutral-950) |
+| `--card` | `#09090b` | Slightly-cooler recessed surface (zinc-950) |
+| `--popover` | `#18181b` | Dropdowns, menus (zinc-900) |
+| `--muted-surface` | `#27272a` | Filled panels, image placeholders (zinc-800) |
+| `--foreground` | `#fafafa` | Primary text, headlines |
+| `--muted-foreground` | `#a1a1aa` | Body copy, labels, metadata (zinc-400) |
+
+> **Body copy is `#a1a1aa`, not white.** This is the single biggest driver of the calm, low-contrast
+> feel. White is reserved for headlines and links.
+
+### Lines & edges
+
+| Token | Value | Use |
+|---|---|---|
+| `--border` | `rgba(255,255,255,0.13)` | The default hairline — grid rules, rails, section dividers |
+| `--border-strong` | `rgba(255,255,255,0.15)` | Hover / emphasis edges |
+| `--input` | `rgba(255,255,255,0.08)` | Field borders, subtle inner edges, nav hover fill |
+| `--rule` | `#27272a` | **Opaque** divider — used inside the mobile menu instead of `--border` |
+
+That last one is a real distinction: translucent `--border` everywhere on the page, opaque `--rule`
+inside the solid-background mobile menu (where a translucent line over a solid panel would read wrong).
+
+### Accent
+
+| Token | Value | Use |
+|---|---|---|
+| `--accent` | `#ac8dff` | The brand violet — primary button fill, italic headline emphasis, category labels |
+| `--accent-2` | `#d4c0ff` | Lighter tint — focus rings, hover lift |
+| `--accent-wash` | `#2a1d4a` | Deep muted violet for large tinted areas |
+| `--accent-orchid` | `#cd82f0` | Pink-leaning secondary accent, gradient artwork only |
+| `--destructive` | `#ef4444` | Errors |
+
+### Gradients & glows
+
+```css
+--gradient-purple-base:   linear-gradient(90deg, #5b1ccc 0%, #7c3aed 50%, #9866f6 100%);
+--gradient-purple-lifted: linear-gradient(90deg, #ac8dff 0%, #c0a6ff 50%, #d4c0ff 100%);
+--gradient-accent:        var(--gradient-purple-lifted);  /* the on-dark default */
+
+--accent-glow:      0 0 20px 2px #7c3aed40;                 /* box-shadow  */
+--accent-text-glow: 0 0 22px #7c3aed33, 0 0 44px #7c3aed1c; /* text-shadow */
+```
+
+The **lifted** gradient is the on-dark default (readable against `#0a0a0a`); the **base** gradient is for
+light or inverted surfaces. Full-bleed gradient bands — a soft violet→lilac wash occupying a whole
+section — are the site's one moment of saturated colour, used to break up long runs of black.
+
+---
+
+## 3. Typography
+
+Three families, three jobs. This split is non-negotiable if you want the look. **All three are SIL Open
+Font License** and free to self-host or serve from Google Fonts.
+
+```css
+--font-serif: Newsreader, Georgia, "Times New Roman", ui-serif, serif;
+--font-sans:  Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+--font-label: "Chakra Petch", ui-monospace, "SF Mono", Menlo, monospace;
+```
+
+- **Serif — Newsreader.** Every heading, plus hero lead-ins and mobile menu items. Always weight **400** —
+  never bold a headline. See §7 for why this font and how it was chosen.
+- **Sans — Inter.** Body copy, links, buttons, navigation. Weights 400/500/600/700.
+- **Label — Chakra Petch.** Uppercase micro-type only: eyebrows, tickers, metadata, footer headings,
+  stat labels, dates, categories. Never for sentences.
+
+### Scale, and how it responds
+
+Only **h1 and h2 scale**. Body, labels, and h3 are fixed at every width — worth internalising, because
+it means you do not need a fluid type system to reproduce this.
+
+| Role | Family | < 768 | 768–1023 | ≥ 1024 | Tracking | Weight | Colour |
+|---|---|---|---|---|---|---|---|
+| Display (h1) | serif | `48px / 1.0` | `60px / 1.0` | `60px / 1.0` | `-0.05em` | 400 | `--foreground` |
+| Section head (h2) | serif | `28px / 1.2` | `28px / 1.2` | `32px / 1.2` | `-0.023em` | 400 | `--foreground` |
+| Card head (h3) | serif | `24px / 1.2` | `24px / 1.2` | `24px / 1.2` | `-0.025em` | 400 | `--foreground` |
+| Menu item (mobile) | serif | `20px / 28px` | — | — | normal | 400 | `--foreground` |
+| Lead paragraph | serif | `20px / 26px` | same | same | normal | 400 | `--foreground` |
+| Body | sans | `16px / 1.6` | same | same | normal | 400 | `--muted-foreground` |
+| Small | sans | `13px / 1.6` | same | same | normal | 400 | `--muted-foreground` |
+| Caption | sans | `12px / 1.43` | same | same | normal | 400 | `--muted-foreground` |
+| **Label / eyebrow** | label | `11px / 18px` | same | same | `0.1em` | **500** | `--muted-foreground` |
+
+Notes on the numbers:
+
+- **h1 tracking is proportional, not fixed** — measured `-3px` at 60px and `-2.4px` at 48px, i.e. `-0.05em`
+  at both. Express it in `em` and it survives any resize.
+- **h1 line-height is exactly 1.0** at every width. Dense, editorial, slightly uncomfortable — deliberately.
+- **The 11px label never changes size.** It's 11px at 375 and at 1440. Same tracking, same weight.
+- The h1 step happens at **768** (md); the h2 step at **1024** (lg). They are not the same breakpoint.
+
+### The headline emphasis pattern
+
+The signature move: one word inside the h1 set in **serif italic, accent-coloured, with a soft glow**.
+
+```html
+<h1 class="display">
+  <span class="block"><em class="headline-italic accent-em">Device</em><em class="headline-italic">-native</em></span>
+  <span class="block">foundation models.</span>
+</h1>
+```
+
+The italic carries its own optical correction — this is lifted verbatim from the site:
+
+```css
+.headline-italic { font-style: italic; font-size: 1.05em; letter-spacing: -0.03em; }
+.accent-em       { color: var(--accent); text-shadow: var(--accent-text-glow); }
+```
+
+**The italic is scaled up 5% and tracked looser than the roman** (`-0.03em` against the headline's
+`-0.05em`). Italics optically shrink and their sloped forms need more room; without this correction the
+emphasis reads smaller and cramped. It's the kind of detail that separates a copy from the real thing.
+
+Also note that in `Device-native`, *both* words are italic — the italic spans a whole phrase, while the
+colour and glow pick out just one word inside it. And headlines break onto explicit lines via
+`display:block` spans, not by letting the browser wrap.
+
+---
+
+## 4. Space & radius
+
+### Radius
+
+```css
+--radius-sm:   4px;    /* header/nav controls, the mobile menu's full-width CTA */
+--radius-md:   6px;    /* icon buttons — hamburger, close */
+--radius-lg:  12px;    /* rare — large media containers */
+--radius-pill: 9999px; /* all body CTAs */
+```
+
+**Radius discipline matters.** Content containers are **square** — 0px radius everywhere. Adding rounded
+cards is the fastest way to lose the look.
+
+### The spacing scale steps once, at `lg` (1024px)
+
+Every spacing token has a compact value below 1024 and a roomy value at/above it. There is no gradual
+interpolation — it is a single hard step. `--spacing-page-x` steps a second time at `xl` (1280).
+
+| Token | < 1024 | ≥ 1024 (lg) | ≥ 1280 (xl) |
+|---|---|---|---|
+| `--spacing-page-x` | `0` | `50px` | `128px` |
+| `--spacing-frame-gutter` | `16px` | `32px` | `32px` |
+| **effective page padding** | **`16px`** | **`82px`** | **`160px`** |
+| `--spacing-content-sm` | `16px` | `24px` | `24px` |
+| `--spacing-content-lg` | `32px` | `48px` | `48px` |
+| `--spacing-content-xl` | `32px` | `64px` | `64px` |
+| `--spacing-section` | `96px` | `128px` | `128px` |
+| `--section-gap-sm` | `64px` | `80px` | `80px` |
+| `--section-gap-md` | `80px` | `96px` | `96px` |
+| `--section-gap-lg` | `96px` | `128px` | `128px` |
+| `--spacing-hero-top` | `130px` | `150px` | `150px` |
+| `--page-max-w` | `1440px` | `1440px` | `1440px` |
+
+Measured section padding follows from this: **`64px` top / `96px` bottom below lg**, **`80px` / `128px` at lg+**.
+Note the asymmetry — bottom padding is always larger than top.
+
+### Breakpoints
+
+Tailwind v4 defaults, plus two customs:
+
+| Name | Width | What changes |
+|---|---|---|
+| `sm` | 640px | minor |
+| `md` | 768px | **h1 48→60px**; hero CTAs stop stacking; stat grid 2→3 cols |
+| `lg` | 1024px | **the big one** — whole spacing scale steps up; ruled grids become grids; 12-col grid activates; h2 28→32px |
+| `xl` | 1280px | **hamburger → full horizontal nav**; page-x 50→128px; header bottom border removed |
+| `2xl` | 1536px | minor |
+| custom | 480px, 896px | isolated tweaks |
+| custom | `max-width: 767px` | marquee slows down |
+
+---
+
+## 5. Layout
+
+### The ruled grid — and how it collapses
+
+The core layout device, and the single most important responsive behaviour on the site:
+
+```html
+<div class="ruled-grid"> <!-- flex column below lg, 3-col grid at lg+ -->
+  <div>…</div><div>…</div><div>…</div>
+</div>
+```
+
+- **Below 1024:** a **flex column** with **horizontal** hairline dividers between items (`divide-y`).
+  Each cell keeps its `32px` padding. Vertical rules do not exist here.
+- **At 1024+:** becomes a **3-column grid** and the horizontal dividers are switched **off**
+  (`lg:divide-y-0`). The vertical separation is then supplied by the rail overlay below, not by borders.
+
+This flip — horizontal dividers on mobile, vertical rails on desktop — is what lets the same content read
+as a ruled grid at both ends. Getting it wrong (e.g. keeping vertical borders and letting them collapse
+into a single column) is the most common way this design fails on a phone.
+
+A second, simpler variant exists for looser content: `grid-cols-1 gap-12` → `lg:grid-cols-3 lg:gap-16`,
+i.e. pure whitespace separation with **no dividers at all**, gaps stepping **48px → 64px**.
+
+### Vertical rails
+
+The vertical lines are **not borders**. They are absolutely-positioned 1px divs
+(`position:absolute; width:1px; background:var(--border)`) spanning a section's full height. Measured
+left offsets:
+
+| Viewport | Rail positions | Count |
+|---|---|---|
+| 375 | `16, 358` | 2 — content edges only |
+| 1024 | `0, 50, 358, 666, 973` | 5 — frame + 3 interior |
+| 1280 | `0, 128, 469, 811, 1151` | 5 |
+| 1440 | `0, 128, 523, 917, 1311` | 5 |
+
+So: on mobile just the two frame edges; from `lg` a full four-column rail grid. Because they're
+positioned elements rather than borders, they run the whole height of a section independent of the
+content inside it — which is exactly what makes it look like printed grid paper rather than a stack of
+bordered divs.
+
+### Page grid
+
+A **12-column** grid with `32px` column gap and `64px` row gap activates at `lg`. Below that everything
+is a single column. Max width `1440px`, centred.
+
+### Article / list rows
+
+| | ≥ lg | < lg |
+|---|---|---|
+| Structure | CSS grid | flex column |
+| Template | `160px minmax(0,1fr) auto` — or `160px 160px minmax(0,1fr) auto` with a category | — |
+| Date | fixed 160px lead column | `display:none`; a duplicate date renders inline above the title |
+| Category | own 160px column | inline, next to the date |
+| Title | serif, fills remaining space | serif, on its own line below |
+| Divider | full-bleed 1px `--border` | same |
+| Row height | ~90px | 113–137px |
+
+Rendered desktop: `08.05 · NEWS · Headline… · →`. Rendered mobile:
+
+```
+08.05  NEWS
+MacPaw Partners with Liquid AI to
+Bring On-Device AI to Millions…
+```
+
+**The category label is accent-coloured** (`#ac8dff`, 11px uppercase) while the date stays
+`--muted-foreground`. One of the few places the accent appears in body content.
+
+---
+
+## 6. Components
+
+### Header / nav
+
+Sticky, `top: 0`, `z-index: 50`, height **69px**. It is **frosted, not transparent** — the effect comes
+from a pseudo-element sitting behind the content:
+
+```css
+.site-header { position: sticky; top: 0; z-index: 50; isolation: isolate;
+               border-bottom: 1px solid var(--border); }
+.site-header::before {
+  content: ""; position: absolute; inset: 0; z-index: -10;
+  background: rgb(10 10 10 / 0.8);
+  backdrop-filter: blur(20px);
+}
+@media (min-width: 1280px) { .site-header { border-bottom: 0; } }
+```
+
+Over the black hero this reads as fully transparent; over a gradient band it reads as smoked glass.
+At `xl` the bottom border is **removed** — the frame rails take over that job.
+
+**Navigation switches at `xl` (1280px), not at `lg`.** Tablets and small laptops get the hamburger.
+
+- **≥1280:** horizontal links, 14px Inter, `#fafafa`, 36px tall, `0 16px`, `4px` radius (radius only visible
+  on hover fill). Solid white pill CTA at the right.
+- **<1280:** a 36×36 icon button, `6px` radius, `aria-label="Open menu"` / `"Close menu"`.
+
+### Mobile menu — the biggest departure from desktop
+
+This is where the design does something genuinely different rather than just reflowing:
+
+```css
+.mobile-menu {
+  position: fixed;
+  inset: 106px 0 0;            /* below ticker (38px) + header (69px) */
+  background: var(--background); /* solid — no blur, no scrim */
+  z-index: 40;
+  overflow-y: auto;
+}
+```
+
+| Element | Spec |
+|---|---|
+| Top-level item | **serif 20px / 28px, weight 400, normal tracking** — not the 14px Inter of desktop |
+| Row | full-bleed, 60px tall, `16px` padding, hover → underline |
+| Divider | 1px **`--rule`** (`#27272a`, opaque) — not `--border` |
+| Expandable | 20×20 chevron in `--muted-foreground`, rotates on open |
+| Submenu item | Inter 16px, `8px 16px` padding, ~37px tall |
+| Footer CTA | **full-width**, `#fafafa` bg, `#0a0a0a` text, `4px` radius, 43px tall |
+
+Promoting nav items to 20px serif is a deliberate inversion: on desktop the serif is reserved for
+content and the nav is quiet sans; on mobile, with the menu occupying the whole screen, the nav *becomes*
+the content and gets the editorial treatment. Copy this — it's most of why the mobile menu feels designed
+rather than generated.
+
+### Ticker / marquee
+
+Full-width scrolling strip above the header. **38px** tall, `8px 0` padding, 11px Chakra Petch uppercase
+in `--muted-foreground`, items separated by a small `▪` glyph.
+
+```css
+--mask-marquee: linear-gradient(90deg, transparent, black 64px, black calc(100% - 64px), transparent);
+
+[data-marquee-track] { animation: marquee var(--marquee-duration, 40s) linear infinite; }
+@media (max-width: 767px) {
+  [data-marquee-track] { animation-duration: var(--marquee-duration-mobile, 160s); }
+}
+@media (any-hover: hover) { .group\/marquee:hover [data-marquee-track] { animation-play-state: paused; } }
+@media (prefers-reduced-motion: reduce) { [data-marquee-track] { animation: none !important; } }
+```
+
+**The marquee slows dramatically on small screens** — measured 160s under 768px against 120s above it
+(the CSS default var is 40s; instances override it). Same distance, far less speed: on a narrow screen a
+fast marquee is unreadable and nauseating. Note also the hover-pause is gated behind `any-hover: hover`
+so it doesn't misfire on touch, and the whole thing is disabled under `prefers-reduced-motion`.
+
+### Buttons
+
+| Variant | Fill | Text | Radius | Padding / height |
+|---|---|---|---|---|
+| **Primary** | `#ac8dff` | `#0a0a0a` | pill | `10px 16px` / 41px |
+| **Ghost** | transparent + gradient ring | gradient text | pill | `10px 16px` / 41px |
+| **Header CTA** | `#fafafa` | `#0a0a0a` | `4px` | `0 16px` / 36px |
+| **Outline** | `#09090b` + 1px `--border` | `#fafafa` | `4px` | `0 16px` / 36px |
+| **Mobile menu CTA** | `#fafafa` | `#0a0a0a` | `4px` | full-width / 43px |
+
+All are **weight 400, 14px, sentence case, no letter-spacing.** No uppercase CTAs anywhere — the
+uppercase treatment belongs exclusively to 11px labels. Body CTAs **never go full-width**; they keep
+their intrinsic width and simply stack below 768px.
+
+The ghost button is more interesting than it looks — both its text *and* its border are gradient-filled:
+
+```css
+/* gradient-filled label */
+.btn-gradient-text {
+  background-image: var(--btn-text, var(--gradient-accent));
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+/* 1px gradient border ring, via mask-composite */
+.btn-gradient-ring { position: relative; }
+.btn-gradient-ring::after {
+  content: ""; position: absolute; inset: 0; padding: 1px;
+  border-radius: inherit; pointer-events: none;
+  background: var(--btn-ring, var(--gradient-accent));
+  mask: linear-gradient(#fff 0 0) content-box exclude, linear-gradient(#fff 0 0);
+}
+```
+
+That mask trick paints the gradient only in the 1px padding band — a gradient border without a wrapper
+element. It's why the "Connect with us" button reads violet on mobile screenshots while its computed
+`color` is `#fafafa`.
+
+### Transitions
+
+```css
+--ease-out:   cubic-bezier(0, 0, 0.2, 1);
+--ease-inout: cubic-bezier(0.4, 0, 0.2, 1);
+```
+
+- Links & nav: `0.15s var(--ease-inout)` on `color`, `background-color`
+- Buttons: `0.3s var(--ease-out)` on `color`, `background-color`
+
+Fast, colour-only, no transforms or scale. Motion is restrained to the marquee and gradient artwork.
+
+### Footer
+
+| | Desktop | Mobile |
+|---|---|---|
+| Columns | 4–5 link columns | single column, `64px` row gap |
+| Column heading | 11px uppercase label, `--muted-foreground` | same |
+| Links | Inter 16px, `#fafafa` | same |
+| Bottom bar | copyright left, legal links right | stacked, copyright centred |
+
+Also carries a brand mark, a one-line mission statement in body grey, an `EST. 2023` label, a row of
+monochrome social glyphs, and an underline-only email subscribe field (transparent background, no radius,
+no box).
+
+### Accessibility notes from the audit
+
+Two things worth fixing rather than faithfully copying:
+
+- **Ticker items measure 22px tall** — under the 44px touch-target guideline. They're links. Either pad
+  them out or make them non-interactive.
+- **Body CTAs are 41px** — just under 44px. Bumping padding to `12px 16px` gets you to 45px with no
+  visual cost.
+
+The mobile menu rows (60px) and header controls (36px, but with generous surrounding space) are fine.
+
+---
+
+## 7. Fonts — the open replacement
+
+The original uses **Iowan Old Style**, an Apple system font. It cannot be webfont-served, so on Windows
+and Android the original site already falls back to something else. For a portable system it has to be
+replaced outright.
+
+### How the replacement was chosen
+
+I rendered 16 free serif candidates against Iowan Old Style in the browser and measured each with canvas
+`TextMetrics` at 100px — x-height/cap-height ratio (perceived size) and the advance width of the full
+headline string (whether line breaks hold).
+
+| Font | x-height / cap | Δ vs Iowan | Line width | Δ width |
+|---|---|---|---|---|
+| **Iowan Old Style** *(target)* | 0.687 | — | 1496.8 | — |
+| Libre Caslon Text | 0.688 | +0.001 | 1603.9 | +7.2% |
+| **Petrona** | 0.691 | +0.004 | 1456.8 | −2.7% |
+| **Spectral** | 0.682 | −0.005 | 1487.3 | −0.6% |
+| **Vollkorn** | 0.677 | −0.010 | 1476.8 | −1.3% |
+| Source Serif 4 | 0.675 | −0.012 | 1358.1 | −9.3% |
+| **Gelasio** | 0.700 | +0.013 | 1487.1 | −0.6% |
+| Literata | 0.703 | +0.016 | 1555.7 | +3.9% |
+| Alegreya | 0.706 | +0.019 | 1382.0 | −7.7% |
+| Lora | 0.714 | +0.027 | 1566.7 | +4.7% |
+| PT Serif | 0.714 | +0.027 | 1503.7 | +0.5% |
+| **Newsreader** | 0.716 | +0.029 | 1502.0 | **+0.3%** |
+| Crimson Pro | 0.733 | +0.046 | 1352.5 | −9.6% |
+| Noto Serif | 0.751 | +0.064 | 1599.1 | +6.8% |
+| EB Garamond | 0.620 | −0.067 | 1285.9 | −14.1% |
+| Faustina | 0.762 | +0.075 | 1397.4 | −6.6% |
+| Bitter | 0.762 | +0.075 | 1562.1 | +4.4% |
+
+### Verdict: **Newsreader** (SIL OFL, Production Type)
+
+```css
+--font-serif: Newsreader, Georgia, "Times New Roman", ui-serif, serif;
+```
+
+- **Width match is near-exact (+0.3%)** — headlines break in the same places, so the hero layout holds
+  without retuning.
+- Visually the closest of the set: same Venetian old-style skeleton, same moderate stroke contrast, same
+  sturdy bracketed serifs. Its true italic is calligraphic and slightly more sloped than Iowan's, which
+  actually *helps* the accent-word treatment in §3.
+- It is what the original site itself designates as its non-Apple fallback — so this isn't a guess about
+  what the designers would accept, it's what they already chose.
+- Drawn specifically for screen reading, with a real italic (not an oblique) and a wide weight range.
+
+**One adjustment.** Newsreader's x-height is `0.512em` against Iowan's `0.479em` — it reads **6.9% larger
+at the same pixel size**. Two options:
+
+- *Keep the scale as-is* (recommended). 60px stays 60px; the headline reads slightly more present. This is
+  what the theme CSS does.
+- *Match Iowan optically* — set the display size to **56px** where the original used 60px.
+
+Newsreader ships an optical-size axis (`opsz 6..72`). In testing, manually setting
+`font-variation-settings: 'opsz'` produced no measurable change, so rely on the default
+`font-optical-sizing: auto` rather than driving the axis by hand.
+
+### Alternates, if you want a different flavour
+
+- **Spectral** — the best pure-metric match (−0.6% width, x-ratio within 0.005). Slightly higher contrast
+  and a touch more literary. Use if you want the headlines more refined.
+- **Vollkorn** — warmer, sturdier, a little quirkier. Use if the black canvas feels too austere.
+- **Gelasio** — metric-compatible with Georgia, so it's the safest choice if you must degrade gracefully
+  to a system font.
+
+**Avoid** for this design: EB Garamond and Crimson Pro (x-height far too small — they look weak and lost
+at 60px on black), Source Serif 4 (−9.3% width shifts every line break), Bitter and Faustina (x-height far
+too large — the tight 1.0 line-height stops working).
+
+### The complete open stack
+
+| Role | Font | Licence | Why |
+|---|---|---|---|
+| Serif / display | **Newsreader** | SIL OFL 1.1 | Replaces Iowan Old Style; see above |
+| Sans / body | **Inter** | SIL OFL 1.1 | Unchanged from the original |
+| Label / micro | **Chakra Petch** | SIL OFL 1.1 | Unchanged; the 11px uppercase voice |
+| Mono | **Geist Mono** | SIL OFL 1.1 | Declared in the original's tokens; unused on the homepage |
+
+All four are on Google Fonts and all four may be self-hosted. Single import:
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;1,6..72,400&family=Inter:wght@400;500;600;700&family=Chakra+Petch:wght@400;500;600&display=swap" rel="stylesheet">
+```
+
+Self-hosting is worth it here: three families plus an italic is a lot of network round-trips, and the
+serif is above the fold in the hero.
+
+---
+
+## 8. Applying this to another site
+
+**Minimum viable transplant** (gets ~80% of the feel):
+
+1. Page background `#0a0a0a`, body text `#a1a1aa`, headings `#fafafa`.
+2. Load Newsreader + Inter + Chakra Petch. Every heading → Newsreader 400, `-0.05em` tracking at display size.
+3. Replace card borders and shadows with `1px solid rgba(255,255,255,0.13)` hairlines; container radius → 0.
+4. Recolour CTAs to the `#ac8dff` pill / gradient-ring pill pair.
+5. Eyebrows, metadata, table headers → 11px Chakra Petch uppercase, `0.1em` tracking.
+
+**Then the four things that make it work on mobile:**
+
+6. **Collapse ruled grids to horizontal dividers**, never to orphaned vertical borders (§5).
+7. **Promote mobile nav items to 20px serif** on a solid full-screen panel with opaque `--rule` dividers (§6).
+8. **Step the whole spacing scale at 1024px** — `16px` page padding below, `82px` above (§4).
+9. **Slow any marquee to ~4× on small screens**, pause on `any-hover: hover` only, kill under reduced motion (§6).
+
+**Things that will break the look:**
+
+- Bold headlines (the serif is designed for 400 — bolding reads as a mistake)
+- Rounded cards with drop shadows
+- More than one accent hue on screen
+- Body copy at full white
+- Uppercase buttons, or letter-spaced body text
+- Full-width stacked mobile CTAs (the real ones keep their intrinsic width)
+- Scaling the 11px label down on mobile — it's fixed at every breakpoint
+- A plain-transparent sticky header — the real one is `blur(20px)` over 80% background
+
+**Licensing.** Newsreader, Inter, Chakra Petch, and Geist Mono are all SIL OFL and free for commercial
+use, self-hosting, and modification. The design tokens, layout patterns, and type scale described here are
+generic craft; the Liquid AI **name, logo, wordmark, and copy** are not, and shouldn't be carried across.
+
+---
+
+## 9. Provenance
+
+Colour, spacing, radius, and gradient tokens were read directly from the site's `:root` custom properties
+at each breakpoint. Typography, component dimensions, transitions, and responsive behaviour were read from
+`getComputedStyle()` on live elements — h1/h2/h3, nav links, all button variants, ticker items, mobile menu
+rows, article rows, footer headings — at 375, 640, 768, 1024, 1280, and 1440px. Component CSS
+(`.btn-gradient-ring`, `.btn-gradient-text`, `.headline-italic`, marquee rules) was extracted from the live
+stylesheet rather than inferred. Font metrics in §7 were measured in-browser with canvas `TextMetrics` at
+100px against locally-installed Iowan Old Style.
+
+Not covered: the `2xl` (1536px) breakpoint and the 480px/896px custom breakpoints were identified but their
+specific effects were not isolated; interior pages (blog, model pages) were not sampled — this describes the
+homepage system.

--- a/liquid-theme.css
+++ b/liquid-theme.css
@@ -1,0 +1,570 @@
+/* ============================================================
+   Liquid-style theme — drop-in stylesheet
+   Companion to liquid-design-system.md
+
+   All fonts are SIL Open Font License. Add to <head>:
+   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;1,6..72,400&family=Inter:wght@400;500;600;700&family=Chakra+Petch:wght@400;500;600&display=swap" rel="stylesheet">
+   ============================================================ */
+
+:root {
+  /* ---- surfaces ---- */
+  --background:       #0a0a0a;
+  --card:             #09090b;
+  --popover:          #18181b;
+  --muted-surface:    #27272a;
+
+  /* ---- text ---- */
+  --foreground:       #fafafa;
+  --muted-foreground: #a1a1aa;
+
+  /* ---- lines ---- */
+  --border:           rgba(255, 255, 255, 0.13); /* translucent — page hairlines */
+  --border-strong:    rgba(255, 255, 255, 0.15);
+  --input:            rgba(255, 255, 255, 0.08);
+  --rule:             #27272a;                   /* opaque — dividers on solid panels */
+
+  /* ---- accent ---- */
+  --accent:           #ac8dff;
+  --accent-2:         #d4c0ff;
+  --accent-wash:      #2a1d4a;
+  --accent-orchid:    #cd82f0;
+  --ring:             var(--accent-2);
+  --destructive:      #ef4444;
+
+  --gradient-purple-base:   linear-gradient(90deg, #5b1ccc 0%, #7c3aed 50%, #9866f6 100%);
+  --gradient-purple-lifted: linear-gradient(90deg, #ac8dff 0%, #c0a6ff 50%, #d4c0ff 100%);
+  --gradient-accent:        var(--gradient-purple-lifted);
+
+  --accent-glow:      0 0 20px 2px #7c3aed40;
+  --accent-text-glow: 0 0 22px #7c3aed33, 0 0 44px #7c3aed1c;
+
+  /* ---- type (all OFL) ---- */
+  --font-serif: Newsreader, Georgia, "Times New Roman", ui-serif, serif;
+  --font-sans:  Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-label: "Chakra Petch", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-mono:  "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* ---- space: COMPACT set (< 1024px) ---- */
+  --page-x:        0px;
+  --frame-gutter:  16px;
+  --page-pad:      calc(var(--page-x) + var(--frame-gutter));
+  --page-max-w:    1440px;
+
+  --content-sm:    16px;
+  --content-lg:    32px;
+  --content-xl:    32px;
+
+  --section:       96px;
+  --section-gap-sm: 64px;
+  --section-gap-md: 80px;
+  --section-gap-lg: 96px;
+
+  --section-pt:    64px;
+  --section-pb:    96px;
+
+  /* ---- radius ---- */
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:  12px;
+  --radius-pill: 9999px;
+
+  /* ---- motion ---- */
+  --ease-out:   cubic-bezier(0, 0, 0.2, 1);
+  --ease-inout: cubic-bezier(0.4, 0, 0.2, 1);
+
+  --mask-marquee: linear-gradient(90deg, transparent, black 64px,
+                                  black calc(100% - 64px), transparent);
+  --marquee-duration:        40s;
+  --marquee-duration-mobile: 160s;
+}
+
+/* ---- space: ROOMY set. The whole scale steps once, at lg. ---- */
+@media (min-width: 1024px) {
+  :root {
+    --page-x:        50px;
+    --frame-gutter:  32px;
+    --content-sm:    24px;
+    --content-lg:    48px;
+    --content-xl:    64px;
+    --section:       128px;
+    --section-gap-sm: 80px;
+    --section-gap-md: 96px;
+    --section-gap-lg: 128px;
+    --section-pt:    80px;
+    --section-pb:    128px;
+  }
+}
+@media (min-width: 1280px) {
+  :root { --page-x: 128px; }
+}
+
+/* ============================================================
+   Base
+   ============================================================ */
+
+* { box-sizing: border-box; }
+
+html { background: var(--background); -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+::selection    { background: var(--accent); color: var(--background); }
+:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }
+
+/* ============================================================
+   Typography
+   Only h1 and h2 scale. Body, labels and h3 are fixed.
+   ============================================================ */
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  color: var(--foreground);
+  margin: 0;
+  font-optical-sizing: auto;
+}
+
+h1, .display { font-size: 48px; line-height: 1;   letter-spacing: -0.05em;  }
+h2           { font-size: 28px; line-height: 1.2; letter-spacing: -0.023em; }
+h3           { font-size: 24px; line-height: 1.2; letter-spacing: -0.025em; }
+h4           { font-size: 20px; line-height: 1.3; letter-spacing: -0.02em;  }
+
+@media (min-width: 768px)  { h1, .display { font-size: 60px; } }
+@media (min-width: 1024px) { h2           { font-size: 32px; } }
+
+/* headline emphasis — italic is scaled up 5% and tracked looser than the roman */
+.headline-italic { font-style: italic; font-size: 1.05em; letter-spacing: -0.03em; }
+.accent-em       { color: var(--accent); text-shadow: var(--accent-text-glow); }
+.display .block  { display: block; }
+
+.lead {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  line-height: 1.3;
+  color: var(--foreground);
+}
+
+p { margin: 0 0 1rem; }
+.text-small   { font-size: 13px; line-height: 1.6; }
+.text-caption { font-size: 12px; line-height: 1.43; }
+
+/* the signature 11px label — never changes size at any breakpoint */
+.label,
+.eyebrow {
+  font-family: var(--font-label);
+  font-size: 11px;
+  line-height: 18px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+.label--bright { color: var(--foreground); }
+.label--accent { color: var(--accent); }   /* article categories use this */
+
+/* square bullet motif before eyebrows */
+.eyebrow::before {
+  content: "";
+  display: inline-block;
+  width: 6px; height: 6px;
+  margin-right: 10px;
+  vertical-align: 1px;
+  background: currentColor;
+  opacity: 0.7;
+}
+
+a {
+  color: var(--foreground);
+  text-decoration: none;
+  transition: color 0.15s var(--ease-inout);
+}
+a:hover { color: var(--accent-2); }
+
+/* ============================================================
+   Layout
+   ============================================================ */
+
+.frame {
+  max-width: var(--page-max-w);
+  margin-inline: auto;
+  padding-inline: var(--page-pad);
+}
+
+.section     { padding-top: var(--section-pt); padding-bottom: var(--section-pb); }
+.section--sm { padding-block: var(--section-gap-sm); }
+.section--md { padding-block: var(--section-gap-md); }
+
+.rule      { border-top: 1px solid var(--border); }
+.rule-both { border-block: 1px solid var(--border); }
+
+/* ---- the ruled grid ----------------------------------------
+   Below lg: flex column with HORIZONTAL dividers.
+   At lg+:   3-col grid, dividers off; vertical separation comes
+             from .rails, not from borders.
+   ------------------------------------------------------------ */
+.ruled-grid { display: flex; flex-direction: column; }
+.ruled-grid > *      { padding: var(--content-lg); }
+.ruled-grid > * + *  { border-top: 1px solid var(--border); }
+
+@media (min-width: 1024px) {
+  .ruled-grid {
+    display: grid;
+    grid-template-columns: repeat(var(--cols, 3), minmax(0, 1fr));
+  }
+  .ruled-grid > * + * { border-top: 0; }
+}
+
+/* looser variant: whitespace only, no dividers */
+.gap-grid { display: grid; grid-template-columns: 1fr; gap: 48px; }
+@media (min-width: 1024px) {
+  .gap-grid { grid-template-columns: repeat(var(--cols, 3), minmax(0, 1fr)); gap: 64px; }
+}
+
+/* ---- vertical rails ----------------------------------------
+   1px positioned elements, not borders, so they span the whole
+   section regardless of content height.
+   ------------------------------------------------------------ */
+.rails { position: relative; }
+.rails > .rail {
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 1px;
+  background: var(--border);
+  pointer-events: none;
+}
+/* mobile: content edges only. lg+: reveal the interior rails. */
+.rails > .rail--inner { display: none; }
+@media (min-width: 1024px) {
+  .rails > .rail--inner { display: block; }
+}
+
+/* ---- 12-column page grid (lg+) ---- */
+.page-grid { display: grid; grid-template-columns: 1fr; row-gap: 64px; }
+@media (min-width: 1024px) {
+  .page-grid { grid-template-columns: repeat(12, minmax(0, 1fr)); column-gap: 32px; }
+}
+
+/* ---- article / list row ---- */
+.article-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-block: var(--content-lg);
+  border-top: 1px solid var(--border);
+}
+.article-row__meta { display: flex; gap: 16px; align-items: baseline; }
+.article-row__date { display: none; }              /* the fixed lead column */
+.article-row__title { font-family: var(--font-serif); font-size: 24px; line-height: 1.2;
+                      letter-spacing: -0.025em; color: var(--foreground); }
+
+@media (min-width: 1024px) {
+  .article-row {
+    display: grid;
+    grid-template-columns: 160px minmax(0, 1fr) auto;
+    gap: var(--content-lg);
+    align-items: baseline;
+  }
+  .article-row--category { grid-template-columns: 160px 160px minmax(0, 1fr) auto; }
+  .article-row__date { display: block; }
+  .article-row__meta { display: contents; }        /* hoist date+category into the grid */
+}
+
+/* full-bleed gradient band */
+.gradient-band {
+  background: var(--gradient-accent);
+  color: var(--background);
+  padding-block: var(--section-pt) var(--section-pb);
+}
+
+/* ============================================================
+   Header / nav
+   ============================================================ */
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  isolation: isolate;
+  height: 69px;
+  display: flex;
+  align-items: center;
+  gap: var(--content-sm);
+  border-bottom: 1px solid var(--border);
+}
+/* frosted, not transparent */
+.site-header::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -10;
+  background: rgb(10 10 10 / 0.8);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+@media (min-width: 1280px) { .site-header { border-bottom: 0; } }
+
+/* desktop nav appears at xl (1280), not lg */
+.nav-desktop { display: none; }
+.nav-toggle  { display: inline-flex; }
+@media (min-width: 1280px) {
+  .nav-desktop { display: flex; align-items: center; gap: 4px; }
+  .nav-toggle  { display: none; }
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
+  padding-inline: 16px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  color: var(--foreground);
+  transition: color 0.15s var(--ease-inout), background-color 0.15s var(--ease-inout);
+}
+.nav-link:hover { background: var(--input); color: var(--foreground); }
+
+.nav-toggle {
+  width: 36px; height: 36px;
+  align-items: center; justify-content: center;
+  background: transparent; border: 0;
+  border-radius: var(--radius-md);
+  color: var(--foreground);
+  cursor: pointer;
+}
+
+/* ============================================================
+   Mobile menu — solid panel, nav promoted to serif
+   ============================================================ */
+
+.mobile-menu {
+  position: fixed;
+  inset: 106px 0 0;              /* below ticker (38) + header (69) */
+  z-index: 40;
+  background: var(--background); /* solid: no blur, no scrim */
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+@media (min-width: 1280px) { .mobile-menu { display: none; } }
+
+.mobile-menu__list { list-style: none; margin: 0; padding: 0; }
+.mobile-menu__list > li + li { border-top: 1px solid var(--rule); }  /* opaque rule */
+
+.mobile-menu__item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 60px;
+  padding: 16px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  color: var(--foreground);
+  cursor: pointer;
+}
+/* the key move: nav items become editorial serif */
+.mobile-menu__label {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: 400;
+}
+.mobile-menu__item:hover .mobile-menu__label { text-decoration: underline; }
+
+.mobile-menu__chevron {
+  width: 20px; height: 20px;
+  color: var(--muted-foreground);
+  transition: transform 0.15s var(--ease-inout);
+}
+.mobile-menu__item[aria-expanded="true"] .mobile-menu__chevron { transform: rotate(180deg); }
+
+.mobile-menu__sub { list-style: none; margin: 0; padding: 0 0 8px; }
+.mobile-menu__sub a {
+  display: block;
+  padding: 8px 16px;
+  font-size: 16px;
+  color: var(--foreground);
+}
+
+.mobile-menu__cta {
+  display: block;
+  margin: 24px 16px;
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);   /* not a pill, unlike body CTAs */
+  background: var(--foreground);
+  color: var(--background);
+  font-size: 14px;
+  text-align: center;
+}
+
+/* ============================================================
+   Ticker / marquee
+   ============================================================ */
+
+.ticker {
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  mask-image: var(--mask-marquee);
+  -webkit-mask-image: var(--mask-marquee);
+}
+.ticker__track {
+  display: flex;
+  gap: 48px;
+  white-space: nowrap;
+  padding-block: 8px;
+  animation: marquee var(--marquee-duration) linear infinite;
+}
+.ticker__item {
+  font-family: var(--font-label);
+  font-size: 11px;
+  line-height: 18px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+@keyframes marquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* far slower on small screens — a fast marquee is unreadable on a phone */
+@media (max-width: 767px) {
+  .ticker__track { animation-duration: var(--marquee-duration-mobile); }
+}
+/* pause on hover only where hover really exists */
+@media (any-hover: hover) {
+  .ticker:hover .ticker__track { animation-play-state: paused; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ticker__track { animation: none !important; }
+}
+
+/* ============================================================
+   Buttons
+   ============================================================ */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 41px;
+  padding: 10px 16px;
+  border: 0;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 21px;
+  cursor: pointer;
+  transition: color 0.3s var(--ease-out), background-color 0.3s var(--ease-out),
+              border-color 0.3s var(--ease-out);
+}
+
+.btn--primary { background: var(--accent); color: var(--background); }
+.btn--primary:hover { background: var(--accent-2); color: var(--background); }
+
+.btn--ghost { background: transparent; color: var(--foreground); }
+
+/* compact 4px-radius variants */
+.btn--header  { min-height: 36px; padding: 0 16px; border-radius: var(--radius-sm);
+                background: var(--foreground); color: var(--background); }
+.btn--header:hover { background: var(--accent-2); }
+.btn--outline { min-height: 36px; padding: 0 16px; border-radius: var(--radius-sm);
+                background: var(--card); border: 1px solid var(--border); color: var(--foreground); }
+.btn--outline:hover { border-color: var(--border-strong); }
+
+/* CTA pairs stack below md and keep intrinsic width — never full-bleed */
+.btn-row { display: flex; flex-direction: column; align-items: flex-start; gap: 12px; }
+@media (min-width: 768px) { .btn-row { flex-direction: row; align-items: center; gap: 16px; } }
+
+/* gradient-filled label */
+.btn-gradient-text {
+  background-image: var(--btn-text, var(--gradient-accent));
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+/* 1px gradient border ring, no wrapper element */
+.btn-gradient-ring { position: relative; }
+.btn-gradient-ring::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  padding: 1px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: var(--btn-ring, var(--gradient-accent));
+  mask: linear-gradient(#fff 0 0) content-box exclude, linear-gradient(#fff 0 0);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box exclude, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+}
+
+/* inline text link with arrow */
+.link-arrow { display: inline-flex; align-items: center; gap: 6px; }
+.link-arrow::after { content: "→"; transition: transform 0.15s var(--ease-inout); }
+.link-arrow:hover::after { transform: translateX(2px); }
+
+/* ============================================================
+   Forms
+   ============================================================ */
+
+.field {
+  width: 100%;
+  padding: 8px 0;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 16px;                 /* 16px minimum — stops iOS zoom-on-focus */
+  transition: border-color 0.15s var(--ease-inout);
+}
+.field::placeholder { color: var(--muted-foreground); }
+.field:focus { outline: 0; border-bottom-color: var(--accent); }
+
+/* ============================================================
+   Footer
+   ============================================================ */
+
+.site-footer { border-top: 1px solid var(--border); padding-block: var(--section-pt) var(--section-pb); }
+.site-footer__cols { display: grid; grid-template-columns: 1fr; gap: 64px; }
+@media (min-width: 1024px) {
+  .site-footer__cols { grid-template-columns: 2fr repeat(4, 1fr); gap: 32px; }
+}
+.site-footer .col-heading { margin-bottom: 16px; }   /* pair with .label */
+.site-footer a { font-size: 16px; color: var(--foreground); }
+
+.site-footer__bottom {
+  border-top: 1px solid var(--border);
+  padding-block: 20px;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: center;
+}
+@media (min-width: 1024px) {
+  .site-footer__bottom { flex-direction: row; justify-content: space-between; text-align: left; }
+}
+
+/* ============================================================
+   Utilities
+   ============================================================ */
+
+.glow      { box-shadow: var(--accent-glow); }
+.text-glow { text-shadow: var(--accent-text-glow); }
+.muted     { color: var(--muted-foreground); }
+.bright    { color: var(--foreground); }

--- a/src/app.css
+++ b/src/app.css
@@ -1,158 +1,233 @@
-@import url("https://fonts.googleapis.com/css2?family=Handjet:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;1,6..72,400&family=Inter:wght@400;500;600;700&family=Chakra+Petch:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap");
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
 /* ────────────────────────────────────────────────────────────────
-   GLYPH — a Nothing OS-inspired console. Dark-first.
-   True-black ground, dot-matrix field, Handjet display type, one
-   red LED as the only signal color. Canonical tokens first, then
-   every legacy variable name this codebase uses remapped onto them
-   so older scoped stylesheets inherit the new look untouched.
+   Liquid — near-black editorial canvas. Hairline rules, Newsreader
+   headlines, Inter body, Chakra Petch labels, one periwinkle accent.
+   Canonical Liquid tokens first; legacy GLYPH names remapped so
+   scoped page styles inherit the new look untouched.
    ──────────────────────────────────────────────────────────────── */
 
 :root {
-  /* ── Canonical GLYPH tokens ── */
-  --void: #060607;
-  --panel: #0c0c0e;
-  --panel-hi: #131316;
-  --ink: #eceee9;
-  --ink-soft: #9b9da0;
-  --ink-mute: #5d5f64;
-  --signal: #e8261f;
-  --signal-hi: #ff4a42;
-  --signal-dim: rgba(232, 38, 31, 0.16);
-  --signal-glow: rgba(232, 38, 31, 0.55);
-  --ok: #3ddc84;
-  --line: rgba(255, 255, 255, 0.16);
-  --line-soft: rgba(255, 255, 255, 0.08);
-  --dots: rgba(255, 255, 255, 0.05);
+  /* ---- Liquid surfaces ---- */
+  --background: #0a0a0a;
+  --card: #09090b;
+  --popover: #18181b;
+  --muted-surface: #27272a;
 
-  --font-dots: "Handjet", "JetBrains Mono", ui-monospace, monospace;
-  --font-sans-g: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
-  --font-mono-g: "JetBrains Mono", ui-monospace, monospace;
+  /* ---- Liquid text ---- */
+  --foreground: #fafafa;
+  --muted-foreground: #a1a1aa;
+
+  /* ---- Liquid lines ---- */
+  --border: rgba(255, 255, 255, 0.13);
+  --border-strong: rgba(255, 255, 255, 0.15);
+  --input: rgba(255, 255, 255, 0.08);
+  --rule: #27272a;
+
+  /* ---- Liquid accent ---- */
+  --accent: #ac8dff;
+  --accent-2: #d4c0ff;
+  --accent-wash: #2a1d4a;
+  --accent-orchid: #cd82f0;
+  --ring: var(--accent-2);
+  --destructive: #ef4444;
+
+  --gradient-purple-base: linear-gradient(
+    90deg,
+    #5b1ccc 0%,
+    #7c3aed 50%,
+    #9866f6 100%
+  );
+  --gradient-purple-lifted: linear-gradient(
+    90deg,
+    #ac8dff 0%,
+    #c0a6ff 50%,
+    #d4c0ff 100%
+  );
+  --gradient-accent: var(--gradient-purple-lifted);
+
+  --accent-glow: 0 0 20px 2px #7c3aed40;
+  --accent-text-glow: 0 0 22px #7c3aed33, 0 0 44px #7c3aed1c;
+
+  /* ---- Liquid type ---- */
+  --font-serif: Newsreader, Georgia, "Times New Roman", ui-serif, serif;
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-label: "Chakra Petch", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* ---- Liquid space: compact (< 1024) ---- */
+  --page-x: 0px;
+  --frame-gutter: 16px;
+  --page-pad: calc(var(--page-x) + var(--frame-gutter));
+  --page-max-w: 1440px;
+
+  --content-sm: 16px;
+  --content-lg: 32px;
+  --content-xl: 32px;
+
+  --section: 96px;
+  --section-gap-sm: 64px;
+  --section-gap-md: 80px;
+  --section-gap-lg: 96px;
+
+  --section-pt: 64px;
+  --section-pb: 96px;
+  --spacing-hero-top: 130px;
+
+  /* ---- Liquid radius ---- */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 12px;
+  --radius-pill: 9999px;
+
+  /* ---- Liquid motion ---- */
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --ease-inout: cubic-bezier(0.4, 0, 0.2, 1);
+
+  --mask-marquee: linear-gradient(
+    90deg,
+    transparent,
+    black 64px,
+    black calc(100% - 64px),
+    transparent
+  );
+  --marquee-duration: 40s;
+  --marquee-duration-mobile: 160s;
+
+  /* ── Legacy aliases → Liquid ── */
+  --void: var(--background);
+  --panel: var(--card);
+  --panel-hi: var(--popover);
+  --ink: var(--foreground);
+  --ink-soft: var(--muted-foreground);
+  --ink-mute: #71717a;
+  --signal: var(--accent);
+  --signal-hi: var(--accent-2);
+  --signal-dim: rgba(172, 141, 255, 0.16);
+  --signal-glow: #7c3aed55;
+  --ok: #3ddc84;
+  --line: var(--border);
+  --line-soft: var(--input);
+  --dots: rgba(255, 255, 255, 0.04);
+
+  --font-dots: var(--font-serif);
+  --font-sans-g: var(--font-sans);
+  --font-mono-g: var(--font-mono);
 
   --cell: 22px;
-  --maxw: 1120px;
+  --maxw: var(--page-max-w);
 
-  /* ── Font aliases (legacy + canonical) ── */
-  --font-display: var(--font-dots);
-  --font-heading: var(--font-dots);
-  --font-body: var(--font-sans-g);
-  --font-mono: var(--font-mono-g);
-  --font-grotesk: var(--font-sans-g);
-  --grotesk: var(--font-sans-g);
-  --mono: var(--font-mono-g);
-  --serif: var(--font-sans-g);
-  --hand: var(--font-dots);
+  --font-display: var(--font-serif);
+  --font-heading: var(--font-serif);
+  --font-body: var(--font-sans);
+  --font-grotesk: var(--font-sans);
+  --grotesk: var(--font-sans);
+  --mono: var(--font-mono);
+  --serif: var(--font-serif);
+  --hand: var(--font-serif);
   --math: "STIX Two Text", "Cambria Math", "Times New Roman", serif;
 
-  /* ── Color aliases ── */
-  --ground: var(--void);
-  --bg: var(--void);
-  --bg-surface: var(--panel);
+  --ground: var(--background);
+  --bg: var(--background);
+  --bg-surface: var(--card);
   --bg-surface-hover: rgba(255, 255, 255, 0.05);
-  --paper: var(--panel);
-  --paper-edge: var(--panel-hi);
-  --paper-warm: var(--panel);
-  --paper-dim: var(--panel-hi);
-  --surface-raised: var(--panel);
-  --surface-sunken: var(--void);
-  --modal-bg: var(--panel);
+  --paper: var(--card);
+  --paper-edge: var(--popover);
+  --paper-warm: var(--card);
+  --paper-dim: var(--popover);
+  --surface-raised: var(--card);
+  --surface-sunken: var(--background);
+  --modal-bg: var(--card);
 
-  --accent: var(--ink);
-  --accent-hover: #ffffff;
-  --accent-light: var(--ink);
-  --accent-faint: rgba(255, 255, 255, 0.06);
-  --secondary: var(--ink);
-  --ink-deep: var(--ink);
+  --accent-hover: var(--accent-2);
+  --accent-light: var(--accent-2);
+  --accent-faint: rgba(172, 141, 255, 0.12);
+  --secondary: var(--foreground);
+  --ink-deep: var(--foreground);
 
-  --red: var(--signal);
-  --warn: var(--signal);
+  --red: var(--destructive);
+  --warn: var(--destructive);
   --green: var(--ok);
-  --blueprint: var(--ink);
-  --blueprint-tint: rgba(255, 255, 255, 0.05);
-  --blueprint-tint-strong: rgba(255, 255, 255, 0.1);
+  --blueprint: var(--accent);
+  --blueprint-tint: rgba(172, 141, 255, 0.08);
+  --blueprint-tint-strong: rgba(172, 141, 255, 0.16);
 
-  --text: var(--ink);
-  --text-muted: var(--ink-soft);
-  --text-primary: var(--ink);
-  --text-secondary: var(--ink-soft);
+  --text: var(--foreground);
+  --text-muted: var(--muted-foreground);
+  --text-primary: var(--foreground);
+  --text-secondary: var(--muted-foreground);
   --text-tertiary: var(--ink-mute);
   --text-faint: var(--ink-mute);
 
-  --grid: var(--line-soft);
-  --grid-strong: var(--line);
-  --rule: var(--line);
-  --rule-soft: var(--line-soft);
-  --paper-rule: var(--line-soft);
-  --border: var(--line-soft);
-  --border-strong: var(--line);
-  --border-subtle: var(--line-soft);
+  --grid: var(--input);
+  --grid-strong: var(--border);
+  --rule-soft: var(--input);
+  --paper-rule: var(--input);
+  --border-subtle: var(--input);
 
   --status-complete: var(--ok);
-  --status-in-progress: var(--signal);
+  --status-in-progress: var(--accent);
   --status-planned: var(--ink-mute);
   --complete: var(--ok);
   --planned: var(--ink-mute);
 
   --code-bg: #0a0a0d;
   --overlay-bg: rgba(0, 0, 0, 0.72);
-  --header-bg: rgba(6, 6, 7, 0.78);
+  --header-bg: rgb(10 10 10 / 0.8);
   --nav-bg: var(--header-bg);
-  --header-offset: 92px;
-  --page-glow: rgba(255, 255, 255, 0.03);
+  --header-offset: 69px;
+  --page-glow: transparent;
   --dot-color: var(--dots);
 
-  --selection-bg: var(--signal);
-  --selection-fg: #ffffff;
-  --btn-primary-bg: var(--ink);
-  --btn-primary-fg: var(--void);
-  --btn-primary-hover: var(--signal);
+  --selection-bg: var(--accent);
+  --selection-fg: var(--background);
+  --btn-primary-bg: var(--accent);
+  --btn-primary-fg: var(--background);
+  --btn-primary-hover: var(--accent-2);
 
   --shadow-color: rgba(0, 0, 0, 0.6);
-  --shadow-hard: 0 1px 0 rgba(0, 0, 0, 0.25),
-    0 24px 48px -24px rgba(0, 0, 0, 0.6);
-  --shadow-hard-lg: 0 24px 48px -28px rgba(0, 0, 0, 0.6);
+  --shadow-hard: none;
+  --shadow-hard-lg: none;
 
   /* Agent panel */
-  --agent-bg: rgba(10, 10, 12, 0.96);
-  --agent-border: var(--line-soft);
+  --agent-bg: rgba(10, 10, 10, 0.96);
+  --agent-border: var(--border);
   --agent-shadow: rgba(0, 0, 0, 0.6);
-  --agent-text: var(--ink);
-  --agent-text-secondary: var(--ink-soft);
+  --agent-text: var(--foreground);
+  --agent-text-secondary: var(--muted-foreground);
   --agent-text-faint: var(--ink-mute);
-  --agent-surface: var(--panel-hi);
+  --agent-surface: var(--popover);
   --agent-surface-hover: rgba(255, 255, 255, 0.07);
-  --agent-input-bg: var(--void);
-  --agent-input-border: var(--line-soft);
-  --agent-input-focus: var(--signal);
-  --agent-bubble-user: var(--panel-hi);
-  --agent-bubble-user-text: var(--ink);
-  --agent-bubble-assistant: var(--panel);
-  --agent-bubble-assistant-border: var(--line-soft);
-  --agent-bubble-assistant-text: var(--ink-soft);
+  --agent-input-bg: var(--background);
+  --agent-input-border: var(--border);
+  --agent-input-focus: var(--accent);
+  --agent-bubble-user: var(--popover);
+  --agent-bubble-user-text: var(--foreground);
+  --agent-bubble-assistant: var(--card);
+  --agent-bubble-assistant-border: var(--border);
+  --agent-bubble-assistant-text: var(--muted-foreground);
   --agent-code-bg: var(--code-bg);
-  --agent-badge-bg: var(--panel-hi);
-  --agent-badge-text: var(--ink-soft);
-  --agent-pill-bg: var(--panel);
-  --agent-pill-border: var(--line-soft);
-  --agent-pill-text: var(--ink-soft);
-  --agent-pill-hover-bg: var(--panel-hi);
-  --agent-pill-hover-border: var(--line);
-  --agent-pill-hover-text: var(--ink);
-  --agent-progress-track: var(--panel-hi);
-  --agent-progress-fill: var(--signal);
-  --agent-fab-bg: rgba(10, 10, 12, 0.9);
-  --agent-fab-border: var(--line-soft);
-  --agent-fab-color: var(--ink-soft);
-  --agent-fab-hover-color: var(--ink);
-  --agent-fab-hover-border: var(--line);
+  --agent-badge-bg: var(--popover);
+  --agent-badge-text: var(--muted-foreground);
+  --agent-pill-bg: var(--card);
+  --agent-pill-border: var(--border);
+  --agent-pill-text: var(--muted-foreground);
+  --agent-pill-hover-bg: var(--popover);
+  --agent-pill-hover-border: var(--border-strong);
+  --agent-pill-hover-text: var(--foreground);
+  --agent-progress-track: var(--popover);
+  --agent-progress-fill: var(--accent);
+  --agent-fab-bg: rgba(10, 10, 10, 0.9);
+  --agent-fab-border: var(--border);
+  --agent-fab-color: var(--muted-foreground);
+  --agent-fab-hover-color: var(--foreground);
+  --agent-fab-hover-border: var(--border-strong);
   --agent-fab-shadow: rgba(0, 0, 0, 0.5);
   --agent-fab-pulse-shadow: var(--signal-glow);
-}
 
-/* Shared primitives */
-:root {
+  /* Shared timing / space (kept for existing pages) */
   --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-in: cubic-bezier(0.7, 0, 0.84, 0);
@@ -172,60 +247,104 @@
   --space-3xl: 6rem;
   --space-4xl: 10rem;
 
-  --radius-sm: 2px;
-  --radius-md: 4px;
-  --radius-lg: 6px;
-
   --measure: 65ch;
 }
 
+@media (min-width: 1024px) {
+  :root {
+    --page-x: 50px;
+    --frame-gutter: 32px;
+    --content-sm: 24px;
+    --content-lg: 48px;
+    --content-xl: 64px;
+    --section: 128px;
+    --section-gap-sm: 80px;
+    --section-gap-md: 96px;
+    --section-gap-lg: 128px;
+    --section-pt: 80px;
+    --section-pb: 128px;
+    --spacing-hero-top: 150px;
+  }
+}
+
+@media (min-width: 1280px) {
+  :root {
+    --page-x: 128px;
+  }
+}
+
 @theme {
-  --font-sans: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
-  --font-serif: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-serif: Newsreader, Georgia, "Times New Roman", ui-serif, serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
-  --font-display: "Handjet", "JetBrains Mono", ui-monospace, monospace;
+  --font-display: Newsreader, Georgia, "Times New Roman", ui-serif, serif;
 }
 
 /* ────────────────────────────────────────────────────────────────
-   Light theme — inverted LCD. Same system, paper-white ground.
+   Light theme — inverted Liquid
    ──────────────────────────────────────────────────────────────── */
 [data-theme="light"] {
-  --void: #f1f1ec;
-  --panel: #e8e8e3;
-  --panel-hi: #dededa;
-  --ink: #101012;
-  --ink-soft: #565860;
-  --ink-mute: #8b8d94;
-  --signal: #d81a13;
-  --signal-hi: #b8140e;
-  --signal-dim: rgba(216, 26, 19, 0.12);
-  --signal-glow: rgba(216, 26, 19, 0.35);
-  --line: rgba(0, 0, 0, 0.18);
-  --line-soft: rgba(0, 0, 0, 0.09);
-  --dots: rgba(0, 0, 0, 0.06);
+  --background: #fafafa;
+  --card: #f4f4f5;
+  --popover: #e4e4e7;
+  --muted-surface: #d4d4d8;
 
-  --accent-hover: #000000;
-  --accent-faint: rgba(0, 0, 0, 0.05);
-  --blueprint-tint: rgba(0, 0, 0, 0.045);
-  --blueprint-tint-strong: rgba(0, 0, 0, 0.09);
+  --foreground: #0a0a0a;
+  --muted-foreground: #52525b;
+
+  --border: rgba(0, 0, 0, 0.13);
+  --border-strong: rgba(0, 0, 0, 0.18);
+  --input: rgba(0, 0, 0, 0.08);
+  --rule: #d4d4d8;
+
+  --accent: #8b6ad6;
+  --accent-2: #6b4fc0;
+  --accent-wash: #ede5ff;
+  --accent-orchid: #a855c8;
+  --ring: var(--accent);
+
+  --gradient-purple-base: linear-gradient(
+    90deg,
+    #5b1ccc 0%,
+    #7c3aed 50%,
+    #9866f6 100%
+  );
+  --gradient-purple-lifted: linear-gradient(
+    90deg,
+    #7c3aed 0%,
+    #8b6ad6 50%,
+    #ac8dff 100%
+  );
+  --gradient-accent: var(--gradient-purple-lifted);
+
+  --accent-glow: 0 0 20px 2px #7c3aed33;
+  --accent-text-glow: 0 0 18px #7c3aed22;
+
+  --ink-mute: #71717a;
+  --signal-dim: rgba(139, 106, 214, 0.14);
+  --signal-glow: #7c3aed44;
+  --dots: rgba(0, 0, 0, 0.05);
+
   --bg-surface-hover: rgba(0, 0, 0, 0.05);
-  --code-bg: #101014;
-  --overlay-bg: rgba(255, 255, 255, 0.72);
-  --header-bg: rgba(241, 241, 236, 0.8);
-  --page-glow: rgba(0, 0, 0, 0.02);
+  --accent-faint: rgba(139, 106, 214, 0.1);
+  --blueprint-tint: rgba(139, 106, 214, 0.08);
+  --blueprint-tint-strong: rgba(139, 106, 214, 0.14);
+  --code-bg: #18181b;
+  --overlay-bg: rgba(250, 250, 250, 0.72);
+  --header-bg: rgb(250 250 250 / 0.8);
   --selection-fg: #ffffff;
+  --btn-primary-fg: #fafafa;
 
   --shadow-color: rgba(0, 0, 0, 0.2);
-  --shadow-hard: 0 1px 0 rgba(0, 0, 0, 0.05),
-    0 24px 48px -28px rgba(0, 0, 0, 0.25);
-  --shadow-hard-lg: 0 24px 48px -32px rgba(0, 0, 0, 0.25);
+  --shadow-hard: none;
+  --shadow-hard-lg: none;
 
-  --agent-bg: rgba(241, 241, 236, 0.96);
-  --agent-shadow: rgba(0, 0, 0, 0.25);
-  --agent-fab-bg: rgba(241, 241, 236, 0.9);
-  --agent-fab-shadow: rgba(0, 0, 0, 0.2);
+  --agent-bg: rgba(250, 250, 250, 0.96);
+  --agent-shadow: rgba(0, 0, 0, 0.2);
+  --agent-fab-bg: rgba(250, 250, 250, 0.9);
+  --agent-fab-shadow: rgba(0, 0, 0, 0.15);
   --agent-surface-hover: rgba(0, 0, 0, 0.06);
-  --agent-input-bg: var(--void);
+  --agent-input-bg: var(--background);
 }
 
 /* Base */
@@ -241,55 +360,39 @@ html {
   scroll-behavior: smooth;
   scroll-padding-top: 96px;
   color-scheme: dark;
+  background: var(--background);
+  -webkit-text-size-adjust: 100%;
 }
 
 html[data-theme="light"] {
   color-scheme: light;
 }
 
-body,
-body * {
-  box-sizing: border-box;
-}
-
 body {
-  font-family: var(--font-sans-g);
+  margin: 0;
+  font-family: var(--font-sans);
   font-weight: 400;
-  font-size: 17px;
+  font-size: 16px;
   line-height: 1.6;
-  color: var(--ink);
+  color: var(--muted-foreground);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  background-color: var(--void);
-  /* dot-matrix field */
-  background-image: radial-gradient(
-    circle,
-    var(--dots) 1px,
-    transparent 1.4px
-  );
-  background-size: var(--cell) var(--cell);
+  background-color: var(--background);
+  background-image: none;
   position: relative;
   min-height: 100vh;
-}
-
-/* soft top glow so the field reads as a powered display, not flat black */
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background: radial-gradient(
-    120% 70% at 50% -10%,
-    var(--page-glow),
-    transparent 60%
-  );
-  pointer-events: none;
-  z-index: -1;
+  overflow-x: hidden;
 }
 
 ::selection {
   background: var(--selection-bg);
   color: var(--selection-fg);
+}
+
+:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }
 
 /* Scrollbar */
@@ -301,8 +404,8 @@ body::before {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: var(--panel-hi);
-  border: 2px solid var(--void);
+  background: var(--muted-surface);
+  border: 2px solid var(--background);
   border-radius: 6px;
 }
 ::-webkit-scrollbar-thumb:hover {
@@ -310,85 +413,127 @@ body::before {
 }
 * {
   scrollbar-width: thin;
-  scrollbar-color: var(--panel-hi) transparent;
+  scrollbar-color: var(--muted-surface) transparent;
 }
 
-/* Typography */
+/* Typography — only h1/h2 scale; never bold headlines */
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: var(--font-dots);
-  font-weight: 500;
-  line-height: 1;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  color: var(--ink);
+  font-family: var(--font-serif);
+  font-weight: 400;
+  color: var(--foreground);
+  margin: 0;
+  font-optical-sizing: auto;
+  text-transform: none;
 }
 
-h1 {
-  font-size: clamp(3rem, 8vw, 6rem);
+h1,
+.display {
+  font-size: 48px;
+  line-height: 1;
+  letter-spacing: -0.05em;
 }
 h2 {
-  font-size: clamp(2.1rem, 5vw, 3.2rem);
-  font-weight: 600;
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: -0.023em;
 }
 h3 {
-  font-size: clamp(1.5rem, 3vw, 1.9rem);
-  font-weight: 600;
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: -0.025em;
 }
 h4 {
-  font-size: 1.3rem;
+  font-size: 20px;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
 }
 h5 {
   font-size: 1.1rem;
+  line-height: 1.3;
 }
 h6 {
   font-size: 0.95rem;
+  line-height: 1.3;
+}
+
+@media (min-width: 768px) {
+  h1,
+  .display {
+    font-size: 60px;
+  }
+}
+@media (min-width: 1024px) {
+  h2 {
+    font-size: 32px;
+  }
+}
+
+.headline-italic {
+  font-style: italic;
+  font-size: 1.05em;
+  letter-spacing: -0.03em;
+}
+.accent-em {
+  color: var(--accent);
+  text-shadow: var(--accent-text-glow);
+}
+.display .block {
+  display: block;
+}
+
+.lead {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  line-height: 1.3;
+  color: var(--foreground);
 }
 
 p {
-  font-family: var(--font-sans-g);
+  font-family: var(--font-sans);
   font-size: 1rem;
   line-height: 1.6;
-  color: var(--ink);
+  color: var(--muted-foreground);
+  margin: 0 0 1rem;
+}
+
+.text-small {
+  font-size: 13px;
+  line-height: 1.6;
+}
+.text-caption {
+  font-size: 12px;
+  line-height: 1.43;
 }
 
 a {
-  color: inherit;
+  color: var(--foreground);
   text-decoration: none;
-  border-bottom: 1px solid transparent;
-  transition: color 0.15s, border-color 0.15s;
+  border-bottom: none;
+  transition: color 0.15s var(--ease-inout);
 }
 a:hover {
-  color: var(--accent-hover);
-}
-
-/* global focus ring (never removed) */
-:focus-visible {
-  outline: 2px solid var(--signal);
-  outline-offset: 3px;
-  border-radius: 1px;
+  color: var(--accent-2);
 }
 
 code,
 pre,
 kbd,
 samp {
-  font-family: var(--font-mono-g);
+  font-family: var(--font-mono);
 }
 
-/* inline code — dark chip */
 code {
-  font-family: var(--font-mono-g);
   font-size: 0.86em;
-  background: var(--panel-hi);
-  border: 1px solid var(--line-soft);
+  background: var(--popover);
+  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 1px 5px;
-  color: var(--ink);
+  color: var(--foreground);
 }
 pre code {
   background: none;
@@ -399,88 +544,230 @@ pre code {
 }
 
 /* Layout primitives */
-.container {
+.container,
+.frame {
   position: relative;
   z-index: 2;
-  max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 0 32px;
+  max-width: var(--page-max-w);
+  margin-inline: auto;
+  padding-inline: var(--page-pad);
 }
 
 .section {
-  padding: 88px 0;
-  border-top: 1px solid var(--line-soft);
+  padding-top: var(--section-pt);
+  padding-bottom: var(--section-pb);
+  border-top: 1px solid var(--border);
+}
+.section--sm {
+  padding-block: var(--section-gap-sm);
+}
+.section--md {
+  padding-block: var(--section-gap-md);
 }
 
 .section-title {
-  font-family: var(--font-dots);
-  font-size: clamp(2.6rem, 6vw, 4.4rem);
-  font-weight: 600;
+  font-family: var(--font-serif);
+  font-size: 48px;
+  font-weight: 400;
   line-height: 1;
-  letter-spacing: 0.02em;
+  letter-spacing: -0.05em;
   text-align: left;
-  text-transform: uppercase;
-  color: var(--ink);
+  text-transform: none;
+  color: var(--foreground);
   margin-bottom: 8px;
+}
+@media (min-width: 768px) {
+  .section-title {
+    font-size: 60px;
+  }
 }
 
 .section-subtitle {
-  font-family: var(--font-mono-g);
-  font-size: 12px;
+  font-family: var(--font-label);
+  font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--ink-soft);
+  color: var(--muted-foreground);
   margin-bottom: 40px;
 }
 
-/* Decorative helpers */
-.ascii-rule {
-  display: block;
-  width: 100%;
-  height: 6px;
-  margin: 32px 0;
-  background-image: radial-gradient(
-    circle,
-    var(--ink-mute) 1px,
-    transparent 1.5px
-  );
-  background-size: 8px 6px;
-  background-position: 0 0;
-  background-repeat: repeat-x;
-  user-select: none;
+.rule {
+  border-top: 1px solid var(--border);
+}
+.rule-both {
+  border-block: 1px solid var(--border);
 }
 
-.label {
-  font-family: var(--font-mono-g);
+/* Ruled grid — horizontal dividers below lg; 3-col at lg+ */
+.ruled-grid {
+  display: flex;
+  flex-direction: column;
+}
+.ruled-grid > * {
+  padding: var(--content-lg);
+}
+.ruled-grid > * + * {
+  border-top: 1px solid var(--border);
+}
+@media (min-width: 1024px) {
+  .ruled-grid {
+    display: grid;
+    grid-template-columns: repeat(var(--cols, 3), minmax(0, 1fr));
+  }
+  .ruled-grid > * + * {
+    border-top: 0;
+  }
+}
+
+.gap-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 48px;
+}
+@media (min-width: 1024px) {
+  .gap-grid {
+    grid-template-columns: repeat(var(--cols, 3), minmax(0, 1fr));
+    gap: 64px;
+  }
+}
+
+.rails {
+  position: relative;
+}
+.rails > .rail {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+  pointer-events: none;
+}
+.rails > .rail--inner {
+  display: none;
+}
+@media (min-width: 1024px) {
+  .rails > .rail--inner {
+    display: block;
+  }
+}
+
+.page-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 64px;
+}
+@media (min-width: 1024px) {
+  .page-grid {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    column-gap: 32px;
+  }
+}
+
+.article-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-block: var(--content-lg);
+  border-top: 1px solid var(--border);
+}
+.article-row__meta {
+  display: flex;
+  gap: 16px;
+  align-items: baseline;
+}
+.article-row__date {
+  display: none;
+}
+.article-row__title {
+  font-family: var(--font-serif);
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: -0.025em;
+  color: var(--foreground);
+}
+@media (min-width: 1024px) {
+  .article-row {
+    display: grid;
+    grid-template-columns: 160px minmax(0, 1fr) auto;
+    gap: var(--content-lg);
+    align-items: baseline;
+  }
+  .article-row--category {
+    grid-template-columns: 160px 160px minmax(0, 1fr) auto;
+  }
+  .article-row__date {
+    display: block;
+  }
+  .article-row__meta {
+    display: contents;
+  }
+}
+
+.gradient-band {
+  background: var(--gradient-accent);
+  color: var(--background);
+  padding-block: var(--section-pt) var(--section-pb);
+}
+
+/* Labels */
+.label,
+.eyebrow {
+  font-family: var(--font-label);
   font-size: 11px;
+  line-height: 18px;
   font-weight: 500;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--ink-soft);
+  color: var(--muted-foreground);
+}
+.label--bright {
+  color: var(--foreground);
+}
+.label--accent {
+  color: var(--accent);
+}
+.eyebrow::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 10px;
+  vertical-align: 1px;
+  background: currentColor;
+  opacity: 0.7;
 }
 
 .fig-label {
-  font-family: var(--font-mono-g);
+  font-family: var(--font-label);
   font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--signal);
+  color: var(--accent);
 }
 
-/* LED — the signature dot. Red, lit, gently pulsing. */
+.ascii-rule {
+  display: block;
+  width: 100%;
+  height: 1px;
+  margin: 32px 0;
+  background: var(--border);
+  user-select: none;
+}
+
+/* Accent marker (replaces red LED) */
 .led {
   display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--signal);
-  box-shadow: 0 0 6px var(--signal-glow), 0 0 2px var(--signal);
+  width: 6px;
+  height: 6px;
+  border-radius: 0;
+  background: var(--accent);
+  box-shadow: none;
   flex-shrink: 0;
-  animation: led-pulse 2.4s ease-in-out infinite;
+  animation: none;
+  opacity: 0.85;
 }
-
 .led-hollow {
   background: transparent;
   border: 1px solid var(--ink-mute);
@@ -492,92 +779,249 @@ pre code {
   0%,
   100% {
     opacity: 1;
-    box-shadow: 0 0 6px var(--signal-glow), 0 0 2px var(--signal);
   }
   50% {
     opacity: 0.55;
-    box-shadow: 0 0 2px var(--signal-glow);
   }
 }
 
 .dropcap > p:first-of-type::first-letter,
 p.dropcap::first-letter {
-  font-family: var(--font-dots);
+  font-family: var(--font-serif);
   float: left;
   font-size: 4.2rem;
   line-height: 0.85;
   padding: 0.08em 0.12em 0 0;
-  color: var(--signal);
+  color: var(--accent);
+  font-weight: 400;
 }
 
 /* Buttons */
 .btn {
-  font-family: var(--font-mono-g);
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  padding: 12px 20px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--ink);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 41px;
+  padding: 10px 16px;
+  border: 0;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 21px;
+  letter-spacing: normal;
+  text-transform: none;
   cursor: pointer;
-  display: inline-block;
   text-align: center;
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+  transition:
+    color 0.3s var(--ease-out),
+    background-color 0.3s var(--ease-out),
+    border-color 0.3s var(--ease-out);
+  background: transparent;
+  color: var(--foreground);
 }
 
 .btn:hover {
-  color: var(--void);
-  background: var(--ink);
-  border-color: var(--ink);
+  color: var(--foreground);
+  background: var(--input);
 }
 
-.btn-primary {
+.btn-primary,
+.btn--primary {
   background: var(--btn-primary-bg);
   color: var(--btn-primary-fg);
-  border-color: var(--btn-primary-bg);
+  border: 0;
+}
+.btn-primary:hover,
+.btn--primary:hover {
+  background: var(--btn-primary-hover);
+  color: var(--btn-primary-fg);
 }
 
-.btn-primary:hover {
-  background: var(--signal);
-  color: #ffffff;
-  border-color: var(--signal);
-}
-
-.btn-secondary {
+.btn-secondary,
+.btn--ghost {
   background: transparent;
-  color: var(--ink);
-  border-color: var(--line);
+  color: var(--foreground);
 }
 
-.btn-secondary:hover {
-  color: var(--void);
-  background: var(--ink);
-  border-color: var(--ink);
-}
-
-/* Components: Inputs */
-.input-field {
-  background: var(--void);
-  border: 1px solid var(--line-soft);
+.btn--header {
+  min-height: 36px;
+  padding: 0 16px;
   border-radius: var(--radius-sm);
-  padding: 0.7rem 0.9rem;
-  color: var(--ink);
-  font-size: 0.95rem;
-  font-family: var(--font-sans-g);
-  transition: border-color var(--dur-instant) var(--ease-out-quart);
+  background: var(--foreground);
+  color: var(--background);
+}
+.btn--header:hover {
+  background: var(--accent-2);
+  color: var(--background);
+}
+
+.btn--outline {
+  min-height: 36px;
+  padding: 0 16px;
+  border-radius: var(--radius-sm);
+  background: var(--card);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+}
+.btn--outline:hover {
+  border-color: var(--border-strong);
+}
+
+.btn-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+@media (min-width: 768px) {
+  .btn-row {
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+  }
+}
+
+.btn-gradient-text {
+  background-image: var(--btn-text, var(--gradient-accent));
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+.btn-gradient-ring {
+  position: relative;
+}
+.btn-gradient-ring::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  padding: 1px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: var(--btn-ring, var(--gradient-accent));
+  mask:
+    linear-gradient(#fff 0 0) content-box exclude,
+    linear-gradient(#fff 0 0);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box exclude,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+}
+
+.link-arrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.link-arrow::after {
+  content: "→";
+  transition: transform 0.15s var(--ease-inout);
+}
+.link-arrow:hover::after {
+  transform: translateX(2px);
+}
+
+/* Forms */
+.field,
+.input-field {
   width: 100%;
+  padding: 8px 0;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  transition: border-color 0.15s var(--ease-inout);
 }
-
+.field::placeholder,
 .input-field::placeholder {
-  color: var(--ink-mute);
+  color: var(--muted-foreground);
 }
-
+.field:focus,
 .input-field:focus {
   outline: none;
-  border-color: var(--signal);
+  border-bottom-color: var(--accent);
+}
+
+.input-field {
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--background);
+}
+.input-field:focus {
+  border-color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Ticker / marquee */
+.ticker {
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  mask-image: var(--mask-marquee);
+  -webkit-mask-image: var(--mask-marquee);
+}
+.ticker__track,
+.ticker-track {
+  display: flex;
+  gap: 48px;
+  white-space: nowrap;
+  padding-block: 8px;
+  animation: marquee var(--marquee-duration) linear infinite;
+}
+.ticker__item,
+.ticker-item {
+  font-family: var(--font-label);
+  font-size: 11px;
+  line-height: 18px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+@media (max-width: 767px) {
+  .ticker__track,
+  .ticker-track {
+    animation-duration: var(--marquee-duration-mobile);
+  }
+}
+@media (any-hover: hover) {
+  .ticker:hover .ticker__track,
+  .ticker:hover .ticker-track {
+    animation-play-state: paused;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ticker__track,
+  .ticker-track {
+    animation: none !important;
+  }
+}
+
+/* Utilities */
+.glow {
+  box-shadow: var(--accent-glow);
+}
+.text-glow {
+  text-shadow: var(--accent-text-glow);
+}
+.muted {
+  color: var(--muted-foreground);
+}
+.bright {
+  color: var(--foreground);
 }
 
 /* Anims */
@@ -601,33 +1045,19 @@ p.dropcap::first-letter {
   }
 }
 
-/* power-on flicker for dot-matrix type */
 @keyframes power-on {
-  0% {
+  from {
     opacity: 0;
+    transform: translateY(8px);
   }
-  8% {
-    opacity: 0.9;
-  }
-  16% {
-    opacity: 0.25;
-  }
-  28% {
+  to {
     opacity: 1;
-  }
-  42% {
-    opacity: 0.5;
-  }
-  58% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 1;
+    transform: translateY(0);
   }
 }
 
 .power-on {
-  animation: power-on 0.7s steps(1, end) both;
+  animation: power-on 0.6s var(--ease-out) both;
 }
 
 @keyframes ticker-scroll {
@@ -651,34 +1081,14 @@ p.dropcap::first-letter {
 .fade-in {
   opacity: 0;
   transform: translateY(12px);
-  transition: opacity 0.5s ease, transform 0.5s ease;
+  transition:
+    opacity 0.5s ease,
+    transform 0.5s ease;
 }
 
 .fade-in.visible {
   opacity: 1;
   transform: translateY(0);
-}
-
-/* Responsive */
-@media (max-width: 720px) {
-  .container {
-    padding: 0 22px;
-  }
-  .section {
-    padding: 56px 0;
-  }
-}
-
-@media (max-width: 480px) {
-  body {
-    font-size: 16px;
-  }
-}
-
-@media (min-width: 1440px) {
-  .container {
-    max-width: var(--maxw);
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#060607" />
+    <meta name="theme-color" content="#0a0a0a" />
     <script>
       (function () {
         try {

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -14,7 +14,7 @@ function initial(): Theme {
 function apply(t: Theme): void {
 	document.documentElement.setAttribute('data-theme', t);
 	const meta = document.querySelector('meta[name="theme-color"]');
-	if (meta) meta.setAttribute('content', t === 'dark' ? '#060607' : '#f1f1ec');
+	if (meta) meta.setAttribute('content', t === 'dark' ? '#0a0a0a' : '#fafafa');
 }
 
 export const theme = writable<Theme>(initial());

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import "../app.css";
   import { page } from "$app/stores";
   import AiAgent from "$lib/components/AiAgent.svelte";
@@ -25,7 +25,7 @@
 
   let mobileMenuOpen = false;
 
-  function isActive(href) {
+  function isActive(href: string) {
     return href === "/" ? currentPath === "/" : currentPath.startsWith(href);
   }
 
@@ -43,19 +43,18 @@
 {:else}
   <div class="site-wrapper">
     <header class="site-header">
-      <div class="header-inner">
+      <div class="header-inner frame">
         <a href="/" class="logo" aria-label="ifkash.dev home">
-          <span class="logo-led" aria-hidden="true"></span>
-          <span class="logo-word">IFKASH</span><span class="logo-tld">.DEV</span>
+          <span class="logo-word">ifkash</span><span class="logo-tld">.dev</span>
         </a>
 
-        <nav class="header-nav" aria-label="Primary">
+        <nav class="nav-desktop" aria-label="Primary">
           {#each navItems as item}
-            <a href={item.href} class:active={isActive(item.href)}>
-              {#if isActive(item.href)}<span
-                  class="nav-led"
-                  aria-hidden="true"
-                ></span>{/if}
+            <a
+              href={item.href}
+              class="nav-link"
+              class:active={isActive(item.href)}
+            >
               {item.label}
             </a>
           {/each}
@@ -109,16 +108,36 @@
             </svg>
           </button>
 
+          <a href="/api/cv?format=view" class="btn btn--header header-cta"
+            >Resume</a
+          >
+
           <button
-            class="mobile-menu-btn"
+            class="nav-toggle"
             on:click={toggleMenu}
-            aria-label="Toggle menu"
+            aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
             aria-expanded={mobileMenuOpen}
           >
             {#if mobileMenuOpen}
-              <span aria-hidden="true">×</span>
+              <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6 6l12 12M18 6L6 18"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                />
+              </svg>
             {:else}
-              <span aria-hidden="true">≡</span>
+              <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M4 7h16M4 12h16M4 17h16"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                />
+              </svg>
             {/if}
           </button>
         </div>
@@ -127,30 +146,28 @@
 
     {#if mobileMenuOpen}
       <div class="mobile-menu">
-        <nav class="mobile-nav" aria-label="Mobile">
-          {#each navItems as item, i}
-            <a
-              href={item.href}
-              class="mobile-link"
-              class:active={isActive(item.href)}
-              on:click={closeMenu}
-            >
-              <span class="mobile-index">0{i + 1}</span>
-              <span class="mobile-word">{item.label}</span>
-              {#if isActive(item.href)}<span
-                  class="led"
-                  aria-hidden="true"
-                ></span>{/if}
-            </a>
+        <ul class="mobile-menu__list">
+          {#each navItems as item}
+            <li>
+              <a
+                href={item.href}
+                class="mobile-menu__item"
+                class:active={isActive(item.href)}
+                on:click={closeMenu}
+              >
+                <span class="mobile-menu__label">{item.label}</span>
+              </a>
+            </li>
           {/each}
-        </nav>
-        <div class="mobile-foot">
-          <a
-            href="https://github.com/kashifulhaque"
-            target="_blank"
-            rel="noopener noreferrer"
-            on:click={closeMenu}>GitHub</a
-          >
+        </ul>
+        <a
+          href="https://github.com/kashifulhaque"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="mobile-menu__cta"
+          on:click={closeMenu}>GitHub</a
+        >
+        <div class="mobile-menu__foot">
           <a href="/admin" on:click={closeMenu}>Admin</a>
         </div>
       </div>
@@ -163,12 +180,16 @@
     </main>
 
     <footer class="site-footer">
-      <div class="container footer-inner">
-        <p class="footer-line">
-          <span class="led" aria-hidden="true"></span>
-          © {new Date().getFullYear()} · Kashiful Haque
-        </p>
-        <div class="footer-links">
+      <div class="frame site-footer__inner">
+        <div class="site-footer__brand">
+          <p class="label col-heading">ifkash.dev</p>
+          <p class="site-footer__mission">
+            ML systems, open source, and small tools — built in Bangalore.
+          </p>
+          <p class="label">Est. 2023</p>
+        </div>
+        <div class="site-footer__links">
+          <p class="label col-heading">Elsewhere</p>
           <a
             href="https://github.com/kashifulhaque"
             target="_blank"
@@ -184,8 +205,12 @@
             target="_blank"
             rel="noopener noreferrer">LinkedIn</a
           >
-          <a href="/admin" aria-label="Admin">Admin</a>
+          <a href="/admin">Admin</a>
         </div>
+      </div>
+      <div class="frame site-footer__bottom">
+        <span>© {new Date().getFullYear()} Kashiful Haque</span>
+        <span class="label">Bangalore, IN</span>
       </div>
     </footer>
 
@@ -204,168 +229,141 @@
   /* ─── Header ───────────────────────────────────────────────── */
 
   .site-header {
-    position: fixed;
+    position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
-    z-index: 100;
+    z-index: 50;
+    isolation: isolate;
+    height: 69px;
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .site-header::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -10;
     background: var(--header-bg);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--line-soft);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
   }
 
   .header-inner {
-    max-width: var(--maxw);
-    margin: 0 auto;
-    padding: 0 32px;
-    height: 60px;
+    width: 100%;
+    height: 69px;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 16px;
+    gap: var(--content-sm);
   }
 
   .logo {
     display: flex;
-    align-items: center;
-    gap: 10px;
+    align-items: baseline;
+    gap: 0;
     border-bottom: none;
     white-space: nowrap;
+    margin-right: auto;
+    color: var(--foreground);
   }
 
   .logo:hover {
     border-bottom: none;
-  }
-
-  .logo-led {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
-    background: var(--signal);
-    box-shadow:
-      0 0 6px var(--signal-glow),
-      0 0 2px var(--signal);
-    animation: led-pulse 2.4s ease-in-out infinite;
+    color: var(--foreground);
   }
 
   .logo-word {
-    font-family: var(--font-dots);
-    font-size: 1.55rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
+    font-family: var(--font-serif);
+    font-size: 1.35rem;
+    font-weight: 400;
+    letter-spacing: -0.03em;
     line-height: 1;
-    color: var(--ink);
-    transform: translateY(1px);
+    color: var(--foreground);
   }
 
   .logo-tld {
-    font-family: var(--font-mono-g);
-    font-size: 0.68rem;
+    font-family: var(--font-label);
+    font-size: 11px;
+    font-weight: 500;
     letter-spacing: 0.1em;
-    color: var(--ink-mute);
-    transform: translateY(3px);
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+    margin-left: 2px;
   }
 
   .logo:hover .logo-word {
-    color: var(--accent-hover);
+    color: var(--accent-2);
   }
 
-  .header-nav {
-    display: flex;
-    gap: 26px;
-    align-items: center;
-  }
-
-  .header-nav a {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    font-family: var(--font-mono-g);
-    font-size: 0.72rem;
-    font-weight: 500;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--ink-soft);
-    border-bottom: none;
-    transition: color 0.15s;
-  }
-
-  .header-nav a:hover {
-    color: var(--ink);
-    border-bottom: none;
-  }
-
-  .header-nav a.active {
-    color: var(--ink);
-  }
-
-  .nav-led {
-    width: 5px;
-    height: 5px;
-    border-radius: 50%;
-    background: var(--signal);
-    box-shadow: 0 0 4px var(--signal-glow);
-  }
-
-  .mobile-menu-btn {
+  .nav-desktop {
     display: none;
     align-items: center;
-    justify-content: center;
-    width: 34px;
-    height: 34px;
-    padding: 0;
-    background: transparent;
-    border: 1px solid var(--line-soft);
-    border-radius: var(--radius-sm);
-    color: var(--ink);
-    font-family: var(--font-mono-g);
-    font-size: 1.15rem;
-    line-height: 1;
-    cursor: pointer;
-    transition:
-      border-color 0.15s,
-      color 0.15s,
-      background 0.15s;
+    gap: 4px;
   }
 
-  .mobile-menu-btn:hover {
-    border-color: var(--ink);
-    color: var(--void);
-    background: var(--ink);
+  .nav-link {
+    display: inline-flex;
+    align-items: center;
+    height: 36px;
+    padding-inline: 16px;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: normal;
+    text-transform: none;
+    color: var(--foreground);
+    border-bottom: none;
+    transition:
+      color 0.15s var(--ease-inout),
+      background-color 0.15s var(--ease-inout);
+  }
+
+  .nav-link:hover {
+    background: var(--input);
+    color: var(--foreground);
+    border-bottom: none;
+  }
+
+  .nav-link.active {
+    color: var(--accent);
   }
 
   .header-actions {
     display: flex;
     align-items: center;
     gap: 10px;
+    margin-left: auto;
   }
 
-  .theme-toggle {
+  .header-cta {
+    display: none;
+  }
+
+  .theme-toggle,
+  .nav-toggle {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 34px;
-    height: 34px;
+    width: 36px;
+    height: 36px;
     padding: 0;
     background: transparent;
-    border: 1px solid var(--line-soft);
-    border-radius: var(--radius-sm);
-    color: var(--ink-soft);
+    border: 0;
+    border-radius: var(--radius-md);
+    color: var(--foreground);
     cursor: pointer;
     transition:
-      color 0.15s,
-      border-color 0.15s,
-      background 0.15s;
+      color 0.15s var(--ease-inout),
+      background-color 0.15s var(--ease-inout);
   }
 
-  .theme-toggle:hover {
-    color: var(--void);
-    border-color: var(--ink);
-    background: var(--ink);
+  .theme-toggle:hover,
+  .nav-toggle:hover {
+    background: var(--input);
+    color: var(--foreground);
   }
 
-  /* Icon swap driven purely by [data-theme] — no hydration flash. */
   .theme-toggle .icon-sun {
     display: none;
   }
@@ -379,86 +377,92 @@
     display: inline-flex;
   }
 
-  /* ─── Mobile menu — full-screen console overlay ────────────── */
+  /* ─── Mobile menu ──────────────────────────────────────────── */
 
   .mobile-menu {
     position: fixed;
-    inset: 0;
-    z-index: 200;
+    inset: 69px 0 0;
+    z-index: 40;
+    background: var(--background);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .mobile-menu__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .mobile-menu__list > li + li {
+    border-top: 1px solid var(--rule);
+  }
+
+  .mobile-menu__item {
     display: flex;
-    flex-direction: column;
+    width: 100%;
+    align-items: center;
     justify-content: space-between;
-    background: var(--void);
-    background-image: radial-gradient(
-      circle,
-      var(--dots) 1px,
-      transparent 1.4px
-    );
-    background-size: var(--cell) var(--cell);
-    padding: 96px 32px 40px;
-    animation: fade-in var(--dur-fast) var(--ease-out-expo);
-  }
-
-  .mobile-nav {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .mobile-link {
-    display: flex;
-    align-items: baseline;
-    gap: 18px;
-    padding: 14px 0;
-    border-bottom: 1px solid var(--line-soft);
-    color: var(--ink);
-  }
-
-  .mobile-link:hover {
-    border-bottom-color: var(--line-soft);
-  }
-
-  .mobile-index {
-    font-family: var(--font-mono-g);
-    font-size: 0.72rem;
-    letter-spacing: 0.12em;
-    color: var(--signal);
-  }
-
-  .mobile-word {
-    font-family: var(--font-dots);
-    font-size: clamp(2.4rem, 9vw, 3.6rem);
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    line-height: 1;
-    color: var(--ink);
-  }
-
-  .mobile-link .led {
-    align-self: center;
-    margin-left: auto;
-  }
-
-  .mobile-link.active .mobile-word {
-    color: var(--signal-hi);
-  }
-
-  .mobile-foot {
-    display: flex;
     gap: 24px;
-  }
-
-  .mobile-foot a {
-    font-family: var(--font-mono-g);
-    font-size: 0.72rem;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--ink-soft);
+    min-height: 60px;
+    padding: 16px;
+    color: var(--foreground);
     border-bottom: none;
   }
 
-  .mobile-foot a:hover {
-    color: var(--ink);
+  .mobile-menu__item:hover {
+    border-bottom: none;
+    color: var(--foreground);
+  }
+
+  .mobile-menu__item:hover .mobile-menu__label {
+    text-decoration: underline;
+  }
+
+  .mobile-menu__item.active .mobile-menu__label {
+    color: var(--accent);
+  }
+
+  .mobile-menu__label {
+    font-family: var(--font-serif);
+    font-size: 20px;
+    line-height: 28px;
+    font-weight: 400;
+  }
+
+  .mobile-menu__cta {
+    display: block;
+    margin: 24px 16px;
+    padding: 10px 16px;
+    border-radius: var(--radius-sm);
+    background: var(--foreground);
+    color: var(--background);
+    font-size: 14px;
+    text-align: center;
+    border-bottom: none;
+  }
+
+  .mobile-menu__cta:hover {
+    background: var(--accent-2);
+    color: var(--background);
+    border-bottom: none;
+  }
+
+  .mobile-menu__foot {
+    padding: 0 16px 32px;
+  }
+
+  .mobile-menu__foot a {
+    font-family: var(--font-label);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+    border-bottom: none;
+  }
+
+  .mobile-menu__foot a:hover {
+    color: var(--foreground);
     border-bottom: none;
   }
 
@@ -467,103 +471,111 @@
   .main-content {
     flex: 1;
     width: 100%;
-    padding-top: 60px;
   }
 
-  .main-content .container {
+  .main-content :global(.container) {
     padding-top: 40px;
-    padding-bottom: 96px;
+    padding-bottom: var(--section-pb);
     animation: enter var(--dur-slow) var(--ease-out-expo);
   }
 
   /* ─── Footer ───────────────────────────────────────────────── */
 
   .site-footer {
-    border-top: 1px solid var(--line-soft);
-    padding: 28px 0;
+    border-top: 1px solid var(--border);
+    padding-top: var(--section-pt);
   }
 
-  .footer-inner {
+  .site-footer__inner {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 64px;
+    padding-bottom: var(--section-gap-sm);
+  }
+
+  .site-footer__mission {
+    max-width: 36ch;
+    margin: 0 0 16px;
+    font-size: 16px;
+    color: var(--muted-foreground);
+  }
+
+  .site-footer .col-heading {
+    margin-bottom: 16px;
+  }
+
+  .site-footer__links {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 16px;
-  }
-
-  .footer-line {
-    display: inline-flex;
-    align-items: center;
+    flex-direction: column;
     gap: 10px;
-    font-family: var(--font-mono-g);
-    font-size: 0.7rem;
-    letter-spacing: 0.12em;
-    color: var(--ink-soft);
-    text-transform: uppercase;
   }
 
-  .footer-links {
+  .site-footer__links a {
+    font-size: 16px;
+    color: var(--foreground);
+    border-bottom: none;
+  }
+
+  .site-footer__links a:hover {
+    color: var(--accent-2);
+    border-bottom: none;
+  }
+
+  .site-footer__bottom {
+    border-top: 1px solid var(--border);
+    padding-block: 20px;
+    font-size: 13px;
+    color: var(--muted-foreground);
     display: flex;
-    gap: 24px;
+    flex-direction: column;
+    gap: 12px;
+    text-align: center;
   }
 
-  .footer-links a {
-    font-family: var(--font-mono-g);
-    font-size: 0.7rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--ink-soft);
-    border-bottom: none;
-    transition: color 0.15s;
-  }
+  /* Desktop nav at xl (1280), not lg */
+  @media (min-width: 1280px) {
+    .site-header {
+      border-bottom: 0;
+    }
 
-  .footer-links a:hover {
-    color: var(--ink);
-    border-bottom: none;
-  }
+    .nav-desktop {
+      display: flex;
+    }
 
-  /* ─── Responsive ───────────────────────────────────────────── */
-
-  @media (max-width: 900px) {
-    .header-nav {
+    .nav-toggle {
       display: none;
     }
 
-    .mobile-menu-btn {
+    .header-cta {
       display: inline-flex;
     }
-  }
 
-  @media (max-width: 768px) {
-    .header-inner {
-      height: 56px;
-      padding: 0 20px;
+    .mobile-menu {
+      display: none;
     }
 
-    .logo-word {
-      font-size: 1.35rem;
+    .site-footer__inner {
+      grid-template-columns: 2fr 1fr;
+      gap: 32px;
     }
 
-    .main-content {
-      padding-top: 56px;
-    }
-
-    .footer-inner {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 12px;
+    .site-footer__bottom {
+      flex-direction: row;
+      justify-content: space-between;
+      text-align: left;
     }
   }
 
-  @media (max-width: 480px) {
-    .header-inner {
-      padding: 0 16px;
-      gap: 8px;
+  @media (min-width: 1024px) {
+    .site-footer__inner {
+      grid-template-columns: 2fr 1fr;
+      gap: 32px;
     }
 
-    .footer-links {
-      gap: 16px;
-      flex-wrap: wrap;
+    .site-footer__bottom {
+      flex-direction: row;
+      justify-content: space-between;
+      text-align: left;
     }
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -59,33 +59,35 @@
 </svelte:head>
 
 <section class="hero">
-  <p class="hero-eyebrow">
-    <span class="led" aria-hidden="true"></span>
-    ML Engineer · Bangalore, IN
-  </p>
+  <p class="eyebrow hero-eyebrow">ML Engineer · Bangalore, IN</p>
 
-  <h1 class="hero-title power-on">
-    Kashiful<br />Haque<a href="/fitness" class="dot" aria-label="." rel="nofollow"
-      >.</a
-    >
+  <h1 class="display hero-title power-on">
+    <span class="block">
+      <em class="headline-italic accent-em">Kashiful</em>
+    </span>
+    <span class="block">
+      Haque<a href="/fitness" class="dot" aria-label="." rel="nofollow">.</a>
+    </span>
   </h1>
 
-  <p class="hero-tagline">
+  <p class="lead hero-tagline">
     ML Engineer with 4 YOE pre-training and post-training LLMs with RL
     pipelines, and building high-performance inference systems in C++ and
     Rust. Also building LLM apps on the day job.
   </p>
 
-  <div class="quick-actions">
-    <a href={resumeUrl} class="btn btn-primary">Read Resume &nearr;</a>
-    <a href="/game" class="btn">Enter Game Mode &nearr;</a>
+  <div class="btn-row quick-actions">
+    <a href={resumeUrl} class="btn btn-primary">Read Resume</a>
+    <a href="/game" class="btn btn-gradient-ring">
+      <span class="btn-gradient-text">Enter Game Mode</span>
+    </a>
   </div>
 
   <div class="status-row">
-    <span class="status-chip"><span class="led" aria-hidden="true"></span>Online</span>
-    <span class="status-chip">EXP · 4+ YRS</span>
-    <span class="status-chip">Stack · C++ / Rust / Py</span>
-    <span class="status-chip">Focus · LLM systems</span>
+    <span class="label label--accent">Online</span>
+    <span class="label">Exp · 4+ yrs</span>
+    <span class="label">Stack · C++ / Rust / Py</span>
+    <span class="label">Focus · LLM systems</span>
   </div>
 </section>
 
@@ -93,284 +95,161 @@
   <div class="ticker-track">
     {#each [...tickerItems, ...tickerItems] as item}
       <span class="ticker-item">{item}</span>
-      <span class="ticker-dot"></span>
+      <span class="ticker-sep" aria-hidden="true">▪</span>
     {/each}
   </div>
 </div>
 
 <section class="index-section">
-  <p class="label index-label">Site index</p>
+  <p class="eyebrow index-label">Site index</p>
   <div class="index-list">
     {#each indexRows as row, i}
       <a href={row.href} class="index-row stagger" style="--i: {i}">
-        <span class="index-n">{row.n}</span>
+        <span class="index-n label label--accent">{row.n}</span>
         <span class="index-name">{row.name}</span>
-        <span class="index-desc">{row.desc}</span>
-        <span class="index-arrow" aria-hidden="true">&rarr;</span>
+        <span class="index-desc label">{row.desc}</span>
+        <span class="index-arrow" aria-hidden="true">→</span>
       </a>
     {/each}
   </div>
 </section>
 
 <style>
-  /* ─── Hero ─────────────────────────────────────────────────── */
-
   .hero {
-    min-height: 72vh;
+    min-height: 70vh;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: 48px 0 40px;
+    padding: var(--spacing-hero-top, 48px) 0 40px;
   }
 
   .hero-eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    font-family: var(--font-mono-g);
-    font-size: 0.75rem;
-    font-weight: 500;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: var(--ink-soft);
     margin-bottom: 24px;
   }
 
   .hero-title {
-    font-family: var(--font-dots);
-    font-size: clamp(4rem, 13vw, 10.5rem);
-    font-weight: 600;
-    line-height: 0.88;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-    color: var(--ink);
+    margin: 0;
   }
 
-  /* The trailing period is a deliberately unmarked link to the fitness hub —
-     looks like plain punctuation, but it's clickable. */
+  /* Trailing period → hidden fitness hub link */
   .dot {
-    color: var(--signal);
+    color: var(--accent);
     border-bottom: none;
     cursor: pointer;
-    text-shadow: 0 0 18px var(--signal-glow);
-    transition: color 0.15s;
+    text-shadow: var(--accent-text-glow);
+    transition: color 0.15s var(--ease-inout);
+    font-style: normal;
   }
 
   .dot:hover {
-    color: var(--signal-hi);
+    color: var(--accent-2);
     border-bottom: none;
   }
 
   .hero-tagline {
-    max-width: 640px;
-    margin: 32px 0 0;
-    font-family: var(--font-sans-g);
-    font-size: clamp(1rem, 1.6vw, 1.15rem);
-    line-height: 1.6;
-    color: var(--ink-soft);
+    max-width: 36em;
+    margin: 28px 0 0;
   }
-
-  /* ─── Quick actions ────────────────────────────────────────── */
 
   .quick-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
     margin-top: 36px;
   }
-
-  /* ─── Status row ───────────────────────────────────────────── */
 
   .status-row {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 28px;
+    gap: 16px 24px;
+    margin-top: 32px;
+    padding-top: 24px;
+    border-top: 1px solid var(--border);
   }
-
-  .status-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 7px 12px;
-    border: 1px solid var(--line-soft);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono-g);
-    font-size: 0.66rem;
-    font-weight: 500;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--ink-soft);
-  }
-
-  /* ─── Ticker ───────────────────────────────────────────────── */
 
   .ticker {
-    overflow: hidden;
-    border-top: 1px solid var(--line-soft);
-    border-bottom: 1px solid var(--line-soft);
-    padding: 12px 0;
     margin: 8px 0 0;
-    mask-image: linear-gradient(
-      to right,
-      transparent,
-      black 8%,
-      black 92%,
-      transparent
-    );
-    -webkit-mask-image: linear-gradient(
-      to right,
-      transparent,
-      black 8%,
-      black 92%,
-      transparent
-    );
+    border-top: 1px solid var(--border);
   }
 
-  .ticker-track {
-    display: inline-flex;
-    align-items: center;
-    gap: 28px;
-    white-space: nowrap;
-    animation: ticker-scroll 36s linear infinite;
-    will-change: transform;
+  .ticker-sep {
+    color: var(--muted-foreground);
+    opacity: 0.5;
+    font-size: 8px;
+    align-self: center;
   }
-
-  .ticker-item {
-    font-family: var(--font-mono-g);
-    font-size: 0.72rem;
-    font-weight: 500;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: var(--ink-soft);
-  }
-
-  .ticker-dot {
-    width: 5px;
-    height: 5px;
-    border-radius: 50%;
-    background: var(--signal);
-    box-shadow: 0 0 4px var(--signal-glow);
-    flex-shrink: 0;
-  }
-
-  /* ─── Site index ───────────────────────────────────────────── */
 
   .index-section {
-    padding: 72px 0 24px;
+    padding: var(--section-pt) 0 24px;
   }
 
   .index-label {
-    margin-bottom: 20px;
-    color: var(--ink-mute);
+    margin-bottom: 8px;
   }
 
   .index-list {
     display: flex;
     flex-direction: column;
-    border-top: 1px solid var(--line-soft);
+    border-top: 1px solid var(--border);
   }
 
   .index-row {
     display: grid;
-    grid-template-columns: 48px minmax(0, 1fr) auto 24px;
+    grid-template-columns: 48px minmax(0, 1fr) auto;
     align-items: baseline;
-    gap: 20px;
-    padding: 18px 12px;
-    margin: 0 -12px;
-    border-bottom: 1px solid var(--line-soft);
-    color: var(--ink);
-    transition:
-      background 0.15s,
-      color 0.15s;
+    gap: 16px;
+    padding-block: 20px;
+    border-bottom: 1px solid var(--border);
+    color: var(--foreground);
+    transition: color 0.15s var(--ease-inout);
   }
 
-  .index-row:hover {
-    background: var(--ink);
-    color: var(--void);
-    border-bottom-color: var(--ink);
-  }
-
-  .index-n {
-    font-family: var(--font-mono-g);
-    font-size: 0.72rem;
-    font-weight: 500;
-    letter-spacing: 0.12em;
-    color: var(--signal);
-  }
-
-  .index-row:hover .index-n {
-    color: var(--void);
-  }
-
-  .index-name {
-    font-family: var(--font-dots);
-    font-size: clamp(1.7rem, 4vw, 2.6rem);
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    line-height: 1;
-  }
-
-  .index-desc {
-    font-family: var(--font-mono-g);
-    font-size: 0.68rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--ink-mute);
-    white-space: nowrap;
-  }
-
-  .index-row:hover .index-desc {
-    color: var(--void);
-  }
-
-  .index-arrow {
-    font-family: var(--font-mono-g);
-    font-size: 1rem;
-    color: var(--ink-mute);
-    transition:
-      transform 0.15s,
-      color 0.15s;
+  .index-row:hover .index-name {
+    color: var(--accent-2);
   }
 
   .index-row:hover .index-arrow {
-    color: var(--void);
-    transform: translateX(4px);
+    color: var(--accent);
+    transform: translateX(2px);
   }
 
-  /* ─── Responsive ───────────────────────────────────────────── */
+  .index-n {
+    align-self: baseline;
+  }
+
+  .index-name {
+    font-family: var(--font-serif);
+    font-size: 24px;
+    line-height: 1.2;
+    letter-spacing: -0.025em;
+    color: var(--foreground);
+  }
+
+  .index-desc {
+    display: none;
+    color: var(--muted-foreground);
+  }
+
+  .index-arrow {
+    color: var(--muted-foreground);
+    transition:
+      transform 0.15s var(--ease-inout),
+      color 0.15s var(--ease-inout);
+  }
+
+  @media (min-width: 1024px) {
+    .index-row {
+      grid-template-columns: 80px minmax(0, 1fr) auto auto;
+      gap: 24px;
+    }
+
+    .index-desc {
+      display: inline;
+      justify-self: end;
+    }
+  }
 
   @media (max-width: 900px) {
     .hero {
       min-height: 0;
       padding: 32px 0 28px;
-    }
-
-    .hero-tagline {
-      margin: 24px 0 0;
-    }
-  }
-
-  @media (max-width: 640px) {
-    .index-row {
-      grid-template-columns: 36px minmax(0, 1fr) 20px;
-    }
-
-    .index-desc {
-      display: none;
-    }
-  }
-
-  @media (max-width: 480px) {
-    .hero-title {
-      font-size: clamp(3.2rem, 17vw, 4.6rem);
-      line-height: 0.9;
-    }
-
-    .quick-actions :global(.btn) {
-      width: 100%;
-      max-width: none;
     }
   }
 </style>

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -181,9 +181,9 @@
   }
 
   .project-led {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
+    width: 6px;
+    height: 6px;
+    border-radius: 0;
     border: 1px solid var(--ink-mute);
     background: transparent;
     transform: translateY(10px);
@@ -192,18 +192,16 @@
   }
 
   .project-led.lit {
-    background: var(--signal);
-    border-color: var(--signal);
-    box-shadow:
-      0 0 6px var(--signal-glow),
-      0 0 2px var(--signal);
-    animation: led-pulse 2.4s ease-in-out infinite;
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow: none;
+    animation: none;
   }
 
   .project-led.shipped {
     background: var(--ok);
     border-color: var(--ok);
-    box-shadow: 0 0 5px rgba(61, 220, 132, 0.4);
+    box-shadow: none;
   }
 
   .project-led.archived {
@@ -228,13 +226,13 @@
   }
 
   .project-name {
-    font-family: var(--font-dots);
-    font-size: 1.9rem;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    color: var(--ink);
-    line-height: 1;
+    font-family: var(--font-serif);
+    font-size: 1.5rem;
+    font-weight: 400;
+    letter-spacing: -0.025em;
+    text-transform: none;
+    color: var(--foreground);
+    line-height: 1.2;
   }
 
   .project-name-link {
@@ -242,7 +240,7 @@
   }
 
   .project-name-link:hover .project-name {
-    color: var(--signal-hi);
+    color: var(--accent-2);
   }
 
   .project-links {
@@ -252,34 +250,33 @@
   }
 
   .project-link {
-    font-family: var(--font-mono-g);
-    font-size: 0.64rem;
+    font-family: var(--font-label);
+    font-size: 11px;
     font-weight: 500;
-    letter-spacing: 0.14em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
     padding: 5px 11px;
     background: transparent;
-    color: var(--ink-soft);
-    border: 1px solid var(--line-soft);
+    color: var(--muted-foreground);
+    border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     text-decoration: none;
     transition:
-      color 0.15s,
-      background 0.15s,
-      border-color 0.15s;
+      color 0.15s var(--ease-inout),
+      border-color 0.15s var(--ease-inout);
   }
 
   .project-link:hover {
-    color: var(--void);
-    background: var(--ink);
-    border-color: var(--ink);
+    color: var(--foreground);
+    background: transparent;
+    border-color: var(--border-strong);
   }
 
   .project-desc {
-    font-family: var(--font-sans-g);
+    font-family: var(--font-sans);
     font-size: 0.95rem;
     line-height: 1.6;
-    color: var(--ink-soft);
+    color: var(--muted-foreground);
     max-width: 720px;
   }
 

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -74,23 +74,23 @@
     gap: 20px;
     padding: 22px 12px;
     margin: 0 -12px;
-    border-bottom: 1px solid var(--line-soft);
-    color: var(--ink);
-    transition:
-      background 0.15s,
-      color 0.15s;
+    border-bottom: 1px solid var(--border);
+    color: var(--foreground);
+    transition: color 0.15s var(--ease-inout);
   }
 
   .tool-row:hover {
-    background: var(--ink);
-    color: var(--void);
-    border-bottom-color: var(--ink);
+    color: var(--foreground);
+  }
+
+  .tool-row:hover .tool-name {
+    color: var(--accent-2);
   }
 
   .tool-led {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
+    width: 6px;
+    height: 6px;
+    border-radius: 0;
     border: 1px solid var(--ink-mute);
     background: transparent;
     transform: translateY(10px);
@@ -99,18 +99,16 @@
   }
 
   .tool-led.lit {
-    background: var(--signal);
-    border-color: var(--signal);
-    box-shadow:
-      0 0 6px var(--signal-glow),
-      0 0 2px var(--signal);
-    animation: led-pulse 2.4s ease-in-out infinite;
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow: none;
+    animation: none;
   }
 
   .tool-led.shipped {
     background: var(--ok);
     border-color: var(--ok);
-    box-shadow: 0 0 5px rgba(61, 220, 132, 0.4);
+    box-shadow: none;
   }
 
   .tool-led.archived {
@@ -134,39 +132,39 @@
   }
 
   .tool-name {
-    font-family: var(--font-dots);
-    font-size: 1.9rem;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    line-height: 1;
+    font-family: var(--font-serif);
+    font-size: 1.5rem;
+    font-weight: 400;
+    letter-spacing: -0.025em;
+    text-transform: none;
+    line-height: 1.2;
     color: inherit;
   }
 
   .tool-arrow {
-    font-family: var(--font-mono-g);
+    font-family: var(--font-sans);
     font-size: 1rem;
     color: var(--ink-mute);
     transition:
-      transform 0.15s,
-      color 0.15s;
+      transform 0.15s var(--ease-inout),
+      color 0.15s var(--ease-inout);
   }
 
   .tool-row:hover .tool-arrow {
-    color: var(--void);
+    color: var(--accent);
     transform: translateX(4px);
   }
 
   .tool-desc {
-    font-family: var(--font-sans-g);
+    font-family: var(--font-sans);
     font-size: 0.95rem;
     line-height: 1.6;
-    color: var(--ink-soft);
+    color: var(--muted-foreground);
     max-width: 720px;
   }
 
   .tool-row:hover .tool-desc {
-    color: var(--void);
+    color: var(--muted-foreground);
   }
 
   @media (max-width: 768px) {

--- a/src/routes/work/+page.svelte
+++ b/src/routes/work/+page.svelte
@@ -87,7 +87,7 @@
   .jobs-list {
     display: flex;
     flex-direction: column;
-    border-top: 1px solid var(--line-soft);
+    border-top: 1px solid var(--border);
     padding-top: 0;
   }
 
@@ -98,23 +98,23 @@
     gap: 24px;
     padding: 20px 12px;
     margin: 0 -12px;
-    border-bottom: 1px solid var(--line-soft);
-    transition:
-      background 0.15s,
-      color 0.15s;
-    color: var(--ink);
+    border-bottom: 1px solid var(--border);
+    transition: color 0.15s var(--ease-inout);
+    color: var(--foreground);
   }
 
   .job-row:hover {
-    background: var(--ink);
-    color: var(--void);
-    border-bottom-color: var(--ink);
+    color: var(--foreground);
+  }
+
+  .job-row:hover .job-role {
+    color: var(--accent-2);
   }
 
   .job-led {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
+    width: 6px;
+    height: 6px;
+    border-radius: 0;
     border: 1px solid var(--ink-mute);
     background: transparent;
     transform: translateY(1px);
@@ -122,12 +122,10 @@
   }
 
   .job-led.lit {
-    background: var(--signal);
-    border-color: var(--signal);
-    box-shadow:
-      0 0 6px var(--signal-glow),
-      0 0 2px var(--signal);
-    animation: led-pulse 2.4s ease-in-out infinite;
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow: none;
+    animation: none;
   }
 
   .job-main {
@@ -138,44 +136,45 @@
   }
 
   .job-role {
-    font-family: var(--font-dots);
-    font-size: 1.75rem;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
+    font-family: var(--font-serif);
+    font-size: 1.5rem;
+    font-weight: 400;
+    letter-spacing: -0.025em;
+    text-transform: none;
     color: inherit;
-    line-height: 1;
+    line-height: 1.2;
   }
 
   .job-company {
-    font-family: var(--font-mono-g);
-    font-size: 0.72rem;
-    letter-spacing: 0.12em;
+    font-family: var(--font-label);
+    font-size: 11px;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    color: var(--ink-soft);
+    color: var(--muted-foreground);
   }
 
   .job-row:hover .job-company {
-    color: var(--void);
+    color: var(--muted-foreground);
   }
 
   .job-period {
-    font-family: var(--font-mono-g);
-    font-size: 0.72rem;
-    letter-spacing: 0.08em;
-    color: var(--ink);
+    font-family: var(--font-label);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     text-align: right;
   }
 
   .job-row:hover .job-period {
-    color: var(--void);
+    color: var(--muted-foreground);
   }
 
   .job-location {
-    font-family: var(--font-mono-g);
-    font-size: 0.66rem;
+    font-family: var(--font-label);
+    font-size: 11px;
     letter-spacing: 0.1em;
     color: var(--ink-mute);
     text-transform: uppercase;
@@ -185,7 +184,7 @@
   }
 
   .job-row:hover .job-location {
-    color: var(--void);
+    color: var(--ink-mute);
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Replace the GLYPH console theme with Liquid tokens (Newsreader / Inter / Chakra Petch, periwinkle accent, hairline rules) and remap legacy CSS vars so interior pages inherit
- Restyle site chrome (frosted sticky header, serif mobile menu at <1280px, quieter footer) and rebuild the homepage hero, marquee, and index
- Soften work/projects/tools list styling (drop invert-on-hover and red LEDs); keep light/dark toggle with an inverted Liquid light palette

## Test plan
- [ ] Load homepage in dark mode — serif hero, accent italic, pill + gradient-ring CTAs, slow ticker
- [ ] Resize below/above 1280px — hamburger vs desktop nav; mobile menu uses serif items
- [ ] Toggle light theme — surfaces invert, accent remains readable
- [ ] Spot-check /work, /projects, /tools — titles/hairlines look Liquid, no console invert flash
- [ ] Confirm /game, /editor, and tool subpages still render (full-width apps untouched beyond inherited tokens)


Made with [Cursor](https://cursor.com)